### PR TITLE
feat: added keystore implementation in centralized-relay for sui keystore

### DIFF
--- a/relayer/chains/sui/client/client.go
+++ b/relayer/chains/sui/client/client.go
@@ -2,18 +2,22 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	suimodels "github.com/block-vision/sui-go-sdk/models"
 	suisdk "github.com/block-vision/sui-go-sdk/sui"
+	"go.uber.org/zap"
 )
 
 type Client struct {
 	rpc suisdk.ISuiAPI
+	log *zap.Logger
 }
 
-func NewClient(rpcClient suisdk.ISuiAPI) *Client {
+func NewClient(rpcClient suisdk.ISuiAPI, l *zap.Logger) *Client {
 	return &Client{
 		rpc: rpcClient,
+		log: l,
 	}
 }
 
@@ -23,4 +27,15 @@ func (c Client) GetLatestCheckpointSeq(ctx context.Context) (uint64, error) {
 
 func (c Client) GetCheckpoints(ctx context.Context, req suimodels.SuiGetCheckpointsRequest) (suimodels.PaginatedCheckpointsResponse, error) {
 	return c.rpc.SuiGetCheckpoints(ctx, req)
+}
+
+func (c *Client) GetBalance(ctx context.Context, addr string) ([]suimodels.CoinData, error) {
+	result, err := c.rpc.SuiXGetAllCoins(ctx, suimodels.SuiXGetAllCoinsRequest{
+		Owner: addr,
+	})
+	if err != nil {
+		c.log.Error(fmt.Sprintf("error getting balance for address %s", addr), zap.Error(err))
+		return nil, err
+	}
+	return result.Data, nil
 }

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -33,7 +33,7 @@ func (pc *Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath 
 	client := suiclient.NewClient(rpcClient, logger)
 
 	return &Provider{
-		log:    logger.With(zap.String("nid ", pc.ChainID), zap.String("name", pc.ChainName)),
+		log:    logger.With(zap.String("nid ", pc.NID), zap.String("name", pc.ChainName)),
 		cfg:    pc,
 		client: client,
 	}, nil

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -14,13 +14,13 @@ type Config struct {
 	ChainName string `yaml:"-"`
 	RPCUrl    string `yaml:"rpc-url"`
 	WsUrl     string `yaml:"ws-url"`
-
+	Address   string `json:"address" yaml:"address"`
+	NID       string `json:"nid" yaml:"nid"`
 	PackageID string `yaml:"package-id"`
-
-	HomeDir string `yaml:"home-dir"`
+	HomeDir   string `yaml:"home-dir"`
 }
 
-func (pc Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath string, debug bool, chainName string) (provider.ChainProvider, error) {
+func (pc *Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath string, debug bool, chainName string) (provider.ChainProvider, error) {
 	pc.HomeDir = homePath
 	pc.ChainName = chainName
 
@@ -30,25 +30,24 @@ func (pc Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath s
 
 	rpcClient := suisdk.NewSuiClient(pc.RPCUrl)
 
-	client := suiclient.NewClient(rpcClient)
+	client := suiclient.NewClient(rpcClient, logger)
 
-	return Provider{
+	return &Provider{
 		log:    logger.With(zap.String("nid ", pc.ChainID), zap.String("name", pc.ChainName)),
 		cfg:    pc,
 		client: client,
 	}, nil
 }
 
-func (c Config) SetWallet(string) {
-	//Todo
+func (pc *Config) SetWallet(addr string) {
+	pc.Address = addr
 }
 
-func (c Config) GetWallet() string {
-	//Todo
-	return ""
+func (pc *Config) GetWallet() string {
+	return pc.Address
 }
 
-func (c Config) Validate() error {
+func (pc *Config) Validate() error {
 	//Todo
 	return nil
 }

--- a/relayer/chains/sui/keys.go
+++ b/relayer/chains/sui/keys.go
@@ -2,26 +2,149 @@ package sui
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path"
 
-	relayertypes "github.com/icon-project/centralized-relay/relayer/types"
+	"github.com/block-vision/sui-go-sdk/common/sui_error"
+	"github.com/block-vision/sui-go-sdk/models"
+	"golang.org/x/crypto/blake2b"
 )
 
-func (p Provider) QueryBalance(ctx context.Context, addr string) (*relayertypes.Coin, error) {
-	//Todo
-	return nil, nil
+type KeyPair byte
+
+const (
+	Ed25519Flag            KeyPair = 0
+	Secp256k1Flag          KeyPair = 1
+	suiAddressLength               = 64
+	ed25519PublicKeyLength         = 32
+)
+
+func encodeBase64(value []byte) string {
+	return base64.StdEncoding.EncodeToString(value)
 }
 
-func (p Provider) NewKeystore(string) (string, error) {
-	//Todo
-	return "", nil
+func fromPublicKeyBytesToAddress(publicKey []byte, scheme byte) string {
+	if scheme != byte(Ed25519Flag) && scheme != byte(Secp256k1Flag) {
+		return ""
+	}
+	tmp := []byte{scheme}
+	tmp = append(tmp, publicKey...)
+	hexHash := blake2b.Sum256(tmp)
+	return "0x" + hex.EncodeToString(hexHash[:])[:suiAddressLength]
 }
 
-func (p Provider) RestoreKeystore(context.Context) error {
-	//Todo
+// fetches Ed25519 keypair from the privatekey with flag
+func fetchKeyPair(privateKey []byte) (models.SuiKeyPair, error) {
+	switch privateKey[0] {
+	case byte(Ed25519Flag):
+		privKey := ed25519.NewKeyFromSeed(privateKey[1:])
+		publicKey := privKey.Public().(ed25519.PublicKey)
+		sk := privKey[:ed25519PublicKeyLength]
+		pbInBase64 := encodeBase64(publicKey)
+		return models.SuiKeyPair{
+			Flag:            byte(Ed25519Flag),
+			PrivateKey:      sk,
+			PublicKeyBase64: pbInBase64,
+			PublicKey:       publicKey,
+			Address:         fromPublicKeyBytesToAddress(publicKey, byte(Ed25519Flag)),
+		}, nil
+	default:
+		return models.SuiKeyPair{}, sui_error.ErrUnknownSignatureScheme
+	}
+}
+
+// Restores the addres configured
+func (p *Provider) RestoreKeystore(ctx context.Context) error {
+	path := p.keystorePath(p.cfg.Address)
+	keystore, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	privateKey, err := p.kms.Decrypt(ctx, keystore)
+	if err != nil {
+		return err
+	}
+	p.wallet, err = fetchKeyPair(privateKey)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
-func (p Provider) ImportKeystore(context.Context, string, string) (string, error) {
-	//Todo
-	return "", nil
+// Creates new Ed25519 key
+func (p *Provider) NewKeystore(password string) (string, error) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", err
+	}
+	privateKeyWithFlag := append([]byte{byte(Ed25519Flag)}, priv[:ed25519PublicKeyLength]...)
+	keyPair, err := fetchKeyPair(privateKeyWithFlag)
+	if err != nil {
+		return "", err
+	}
+	keyStoreContent, err := p.kms.Encrypt(context.Background(), privateKeyWithFlag)
+	if err != nil {
+		return "", err
+	}
+	passphraseCipher, err := p.kms.Encrypt(context.Background(), []byte(password))
+	if err != nil {
+		return "", err
+	}
+	path := p.keystorePath(keyPair.Address)
+	if err = os.WriteFile(path, keyStoreContent, 0o644); err != nil {
+		return "", err
+	}
+	if err = os.WriteFile(path+".pass", passphraseCipher, 0o644); err != nil {
+		return "", err
+	}
+
+	return keyPair.Address, nil
+}
+
+// Imports first ed25519 key pair from the keystore
+func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase string) (string, error) {
+	privFile, err := os.ReadFile(keyPath)
+	if err != nil {
+		return "", err
+	}
+	var ksData []string
+	err = json.Unmarshal(privFile, &ksData)
+	if err != nil {
+		return "", err
+	}
+	//decode base64 for first key
+	privateKey, err := base64.StdEncoding.DecodeString(string(ksData[0]))
+	if err != nil {
+		return "", err
+	}
+	keyPair, err := fetchKeyPair(privateKey)
+	if err != nil {
+		return "", err
+	}
+	keyStoreContent, err := p.kms.Encrypt(ctx, privateKey)
+	if err != nil {
+		return "", err
+	}
+	passphraseCipher, err := p.kms.Encrypt(ctx, []byte(passphrase))
+	if err != nil {
+		return "", err
+	}
+	path := p.keystorePath(keyPair.Address)
+	if err = os.WriteFile(path, keyStoreContent, 0o644); err != nil {
+		return "", err
+	}
+	if err = os.WriteFile(path+".pass", passphraseCipher, 0o644); err != nil {
+		return "", err
+	}
+	return keyPair.Address, nil
+}
+
+// keystorePath is the path to the keystore file
+func (p *Provider) keystorePath(addr string) string {
+	return path.Join(p.cfg.HomeDir, "keystore", p.NID(), addr)
 }

--- a/relayer/chains/sui/keys_test.go
+++ b/relayer/chains/sui/keys_test.go
@@ -1,0 +1,25 @@
+package sui
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	expectedAddr    = "0xe847098636459aa93f4da105414edca4790619b291ffdac49419f5adc19c4d21"
+	expectedPrivKey = "b592e26293b6081673c807f9ae5b14b150d0078d6d9a5474323fff73a9015cac"
+)
+
+func TestRestoreKey(t *testing.T) {
+	encodedWithFlag := "ALWS4mKTtggWc8gH+a5bFLFQ0AeNbZpUdDI//3OpAVys"
+	privateKey, err := base64.StdEncoding.DecodeString(encodedWithFlag)
+	assert.NoError(t, err)
+	key, err := fetchKeyPair(privateKey)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedAddr, key.Address)
+	assert.Equal(t, expectedPrivKey, hex.EncodeToString(key.PrivateKey))
+
+}

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/block-vision/sui-go-sdk/models"
 	"github.com/icon-project/centralized-relay/relayer/chains/sui/types"
 	"github.com/icon-project/centralized-relay/relayer/kms"
 	"github.com/icon-project/centralized-relay/relayer/provider"
@@ -13,70 +14,81 @@ import (
 
 type Provider struct {
 	log    *zap.Logger
-	cfg    Config
+	cfg    *Config
 	client types.IClient
+	wallet models.SuiKeyPair
+	kms    kms.KMS
 }
 
-func (p Provider) QueryLatestHeight(ctx context.Context) (uint64, error) {
+func (p *Provider) QueryLatestHeight(ctx context.Context) (uint64, error) {
 	return p.client.GetLatestCheckpointSeq(ctx)
 }
 
-func (p Provider) NID() string {
-	return p.cfg.ChainID
+func (p *Provider) NID() string {
+	return p.cfg.NID
 }
 
-func (p Provider) Name() string {
+func (p *Provider) Name() string {
 	return p.cfg.ChainName
 }
 
-func (p Provider) Init(context.Context, string, kms.KMS) error {
-	//Todo
+func (p *Provider) Init(ctx context.Context, homePath string, kms kms.KMS) error {
+	p.kms = kms
 	return nil
 }
 
 // Type returns chain-type
-func (p Provider) Type() string {
+func (p *Provider) Type() string {
 	return types.ChainType
 }
 
-func (p Provider) Config() provider.Config {
+func (p *Provider) Config() provider.Config {
 	return p.cfg
+}
+
+func (p *Provider) Wallet() (models.SuiKeyPair, error) {
+	if p.wallet.PrivateKey == nil {
+		if err := p.RestoreKeystore(context.Background()); err != nil {
+			return models.SuiKeyPair{}, err
+		}
+	}
+	return p.wallet, nil
 }
 
 // FinalityBlock returns the number of blocks the chain has to advance from current block inorder to
 // consider it as final. In Sui checkpoints are analogues to blocks and checkpoints once published are
 // final. So Sui doesn't need to be checked for block/checkpoint finality.
-func (p Provider) FinalityBlock(ctx context.Context) uint64 {
+func (p *Provider) FinalityBlock(ctx context.Context) uint64 {
 	return 0
 }
 
-func (p Provider) GenerateMessages(ctx context.Context, messageKey *relayertypes.MessageKeyWithMessageHeight) ([]*relayertypes.Message, error) {
+func (p *Provider) GenerateMessages(ctx context.Context, messageKey *relayertypes.MessageKeyWithMessageHeight) ([]*relayertypes.Message, error) {
 	//Todo
 	return nil, nil
 }
 
 // SetAdmin transfers the ownership of sui connection module to new address
-func (p Provider) SetAdmin(context.Context, string) error {
+func (p *Provider) SetAdmin(context.Context, string) error {
 	//Todo
 	return nil
 }
 
-func (p Provider) RevertMessage(context.Context, *big.Int) error {
+func (p *Provider) RevertMessage(context.Context, *big.Int) error {
 	//Todo
 	return nil
 }
 
-func (p Provider) GetFee(context.Context, string, bool) (uint64, error) {
+func (p *Provider) GetFee(context.Context, string, bool) (uint64, error) {
 	//Todo
 	return 0, nil
 }
 
-func (p Provider) SetFee(context.Context, string, uint64, uint64) error {
+func (p *Provider) SetFee(context.Context, string, uint64, uint64) error {
 	//Todo
 	return nil
 }
 
-func (p Provider) ClaimFee(context.Context) error {
+func (p *Provider) ClaimFee(context.Context) error {
 	//Todo
 	return nil
 }

--- a/relayer/chains/sui/provider_test.go
+++ b/relayer/chains/sui/provider_test.go
@@ -49,7 +49,7 @@ func GetSuiProvider() (*Provider, error) {
 
 	suiProvider, ok := prov.(*Provider)
 	if !ok {
-		return nil, fmt.Errorf("unbale to type case to icon chain provider")
+		return nil, fmt.Errorf("unable to type cast to sui chain provider")
 	}
 	suiProvider.Init(ctx, "./tmp/", &mockKms{})
 	err = os.MkdirAll(suiProvider.keystorePath("test"), 0777)

--- a/relayer/chains/sui/provider_test.go
+++ b/relayer/chains/sui/provider_test.go
@@ -1,0 +1,85 @@
+package sui
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+var (
+	privateKeyEncodedWithFlag = "ALWS4mKTtggWc8gH+a5bFLFQ0AeNbZpUdDI//3OpAVys"
+	expectedDecodedAddr       = "0xe847098636459aa93f4da105414edca4790619b291ffdac49419f5adc19c4d21"
+	expectedDecodedPrivKey    = "b592e26293b6081673c807f9ae5b14b150d0078d6d9a5474323fff73a9015cac"
+)
+
+type mockKms struct {
+}
+
+func (*mockKms) Init(context.Context) (*string, error) {
+	initcompleted := "yes"
+	return &initcompleted, nil
+}
+
+func (*mockKms) Encrypt(ctx context.Context, input []byte) ([]byte, error) {
+	return input, nil
+}
+
+func (*mockKms) Decrypt(ctx context.Context, input []byte) ([]byte, error) {
+	return input, nil
+}
+
+func GetSuiProvider() (*Provider, error) {
+	pc := Config{
+		NID:     "sui.testnet",
+		Address: "0xe847098636459aa93f4da105414edca4790619b291ffdac49419f5adc19c4d21",
+		RPCUrl:  "https://sui-devnet-endpoint.blockvision.org",
+		HomeDir: "./tmp/",
+	}
+	logger := zap.NewNop()
+	ctx := context.Background()
+	prov, err := pc.NewProvider(ctx, logger, "./tmp/", true, "sui.testnet")
+	if err != nil {
+		return nil, err
+	}
+
+	suiProvider, ok := prov.(*Provider)
+	if !ok {
+		return nil, fmt.Errorf("unbale to type case to icon chain provider")
+	}
+	suiProvider.Init(ctx, "./tmp/", &mockKms{})
+	err = os.MkdirAll(suiProvider.keystorePath("test"), 0777)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return suiProvider, nil
+}
+
+func TestNewKeystore(t *testing.T) {
+	pro, err := GetSuiProvider()
+	assert.NoError(t, err)
+	generatedKeyStore, err := pro.NewKeystore("password")
+	assert.NoError(t, err)
+	pro.cfg.Address = generatedKeyStore
+	err = pro.RestoreKeystore(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, generatedKeyStore, pro.wallet.Address)
+}
+
+func TestImportKeystore(t *testing.T) {
+	pro, err := GetSuiProvider()
+	assert.NoError(t, err)
+	data := []byte("[\"" + privateKeyEncodedWithFlag + "\"]")
+	os.WriteFile("./tmp/ks.keystore", data, 0644)
+	restoredKeyStore, err := pro.ImportKeystore(context.TODO(), "./tmp/ks.keystore", "passphrase")
+	assert.NoError(t, err)
+	pro.cfg.Address = restoredKeyStore
+	err = pro.RestoreKeystore(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, expectedDecodedAddr, pro.wallet.Address)
+	assert.Equal(t, expectedDecodedPrivKey, hex.EncodeToString(pro.wallet.PrivateKey))
+}

--- a/relayer/chains/sui/query.go
+++ b/relayer/chains/sui/query.go
@@ -1,0 +1,26 @@
+package sui
+
+import (
+	"context"
+	"strconv"
+
+	relayertypes "github.com/icon-project/centralized-relay/relayer/types"
+)
+
+const suiCurrencyDenom = "MIST"
+
+func (p *Provider) QueryBalance(ctx context.Context, addr string) (*relayertypes.Coin, error) {
+	balance, err := p.client.GetBalance(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	var totalBalance uint64 = 0
+	for _, bal := range balance {
+		balance64, err := strconv.ParseUint(bal.Balance, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		totalBalance += (balance64)
+	}
+	return &relayertypes.Coin{Amount: totalBalance, Denom: suiCurrencyDenom}, nil
+}

--- a/relayer/chains/sui/types/types.go
+++ b/relayer/chains/sui/types/types.go
@@ -13,4 +13,5 @@ const (
 type IClient interface {
 	GetLatestCheckpointSeq(ctx context.Context) (uint64, error)
 	GetCheckpoints(ctx context.Context, req suimodels.SuiGetCheckpointsRequest) (suimodels.PaginatedCheckpointsResponse, error)
+	GetBalance(ctx context.Context, addr string) ([]suimodels.CoinData, error)
 }


### PR DESCRIPTION
Added keystore implementation to import/restore or create new sui key in centralized relay. Added function to get the balance of the configured accounts in mist.
Supported only ed25519 keystores for sui similar to sui wallets.
Importing keystore will import only the first account in the keystore