### PR TITLE
fix: wait for block mined instead of poll

### DIFF
--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	RPCCallRetry                               = 5
-	MaxGasPriceInceremtRetry                   = 5
-	GasPriceRatio                              = 10.0
-	DefaultGetTransactionResultPollingInterval = time.Second * 3
+	RPCCallRetry             = 5
+	MaxGasPriceInceremtRetry = 5
+	GasPriceRatio            = 10.0
+	DefaultMinedTimeout      = time.Second * 60
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {
@@ -91,6 +91,7 @@ type IClient interface {
 	TransactionByHash(ctx context.Context, blockHash common.Hash) (tx *ethTypes.Transaction, isPending bool, err error)
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error)
+	WaitForTransactionMined(ctx context.Context, tx *ethTypes.Transaction) (*ethTypes.Receipt, error)
 	TransactionCount(ctx context.Context, blockHash common.Hash) (uint, error)
 	TransactionInBlock(ctx context.Context, blockHash common.Hash, index uint) (*ethTypes.Transaction, error)
 	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
@@ -136,6 +137,15 @@ func (cl *Client) TransactionByHash(ctx context.Context, blockHash common.Hash) 
 
 func (cl *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*ethTypes.Receipt, error) {
 	return cl.eth.TransactionReceipt(ctx, txHash)
+}
+
+// Wait for the transaction to be mined
+func (cl *Client) WaitForTransactionMined(ctx context.Context, tx *ethTypes.Transaction) (*ethTypes.Receipt, error) {
+	receipt, err := bind.WaitMined(ctx, cl.eth, tx)
+	if err != nil {
+		return nil, err
+	}
+	return receipt, nil
 }
 
 func (cl *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -208,10 +208,11 @@ func (p *Provider) FindMessages(ctx context.Context, lbn *types.BlockNotificatio
 
 func (p *Provider) GetConcurrency(ctx context.Context, startHeight, currentHeight uint64) int {
 	diff := int(currentHeight - startHeight)
-	if diff <= runtime.NumCPU() {
+	cpu := runtime.NumCPU()
+	if diff <= cpu {
 		return diff
 	}
-	return runtime.NumCPU()
+	return cpu
 }
 
 func (p *Provider) startFromHeight(ctx context.Context, lastSavedHeight uint64) (uint64, error) {

--- a/relayer/chains/evm/route.go
+++ b/relayer/chains/evm/route.go
@@ -133,7 +133,7 @@ func (p *Provider) WaitForTxResult(
 		TxHash: tx.Hash().String(),
 	}
 
-	txReceipts, err := p.WaitForResults(ctx, tx.Hash())
+	txReceipts, err := p.WaitForResults(ctx, tx)
 	if err != nil {
 		p.log.Error("failed to get tx result",
 			zap.String("hash", res.TxHash),


### PR DESCRIPTION
This pull request fixes the issue with waiting for a block to be mined by using the `WaitForTransactionMined` method instead of polling. It also refactors the `GetConcurrency` method to use the `runtime.NumCPU` function to determine the concurrency level.