### PR TITLE
Update cosmwasm and go-releaser versions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
     main: ./main.go
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.1/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     goos:
       - darwin
     goarch:
@@ -26,7 +26,7 @@ builds:
     main: ./main.go
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.1/libwasmvmstatic_darwin.a -O /lib/libwasmvmstatic_darwin.a
     goos:
       - darwin
     goarch:
@@ -46,7 +46,7 @@ builds:
     main: ./main.go
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.1/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
     goos:
       - linux
     goarch:
@@ -68,7 +68,7 @@ builds:
     main: ./main.go
     hooks:
       pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.0/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v2.0.1/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 
 # Define the URLs for the library files
-LIBWASMV_VERS := "v2.0.0"
-LIBWASMMV_URL := https://github.com/CosmWasm/wasmvm/releases/download/$(LIBWASMV_VERS)
+COSMWASM_VERSION      ?= v2.0.1
+LIBWASMMV_URL := https://github.com/CosmWasm/wasmvm/releases/download/$(COSMWASM_VERSION)
 
 
 
@@ -111,8 +111,7 @@ e2e-test:
 	@go test -v ./test/e2e -testify.m TestE2E_all
 
 PACKAGE_NAME          := github.com/icon-project/centralized-relay
-GOLANG_CROSS_VERSION  ?= v1.22.1
-COSMWASM_VERSION      ?= v2.0.0
+GOLANG_CROSS_VERSION  ?= v1.22.3
 
 SYSROOT_DIR     ?= sysroots
 SYSROOT_ARCHIVE ?= sysroots.tar.bz2


### PR DESCRIPTION
This pull request updates the cosmwasm version to v2.0.1 for bug fixes and improvements. It also updates the go-releaser version to v1.22.3.