### PR TITLE
fix: fallback to polling when RPC fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,117 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.6] - 2024-05-26
+
+### Fixed
+
+- Cosmos contracts subscriptions respects the configured contracts
+- RPC failures are are handled more elegently, switches to the polling and back to the subscriptions
+- Other improvements and bug fixes
+
+### Refactor
+
+- Icon `progressInterval` notification block is not incremented to handle rpc failures
+
+## [1.2.5] - 2024-05-18
+
+### Fixed
+
+- Wrong params sent when estimating gas for the evm chain `executeCall`
+
+## [1.2.4] - 2024-05-17
+
+### Added
+
+- Support for the injective chain
+
+### Fixed
+
+- Gas Estimation for the evm chain
+- Cosmos sdk global config bech32 prefixes
+- Other improvements and bug fixes
+
+## [1.2.3] - 2024-05-14
+
+### Added
+
+- Gas adjustment from config
+
+## [1.2.2] - 2024-05-01
+
+### Fixed
+
+- Avoid nonce increment when fixing the nonce error while sending the transaction
+
+## [1.2.1] - 2024-04-30
+
+### Fixed
+
+- Websocket connection disconnect issue with icon chain
+- Use `eth_gasPrice` for the gas price calculation all the time
+- Other improvements and bug fixes
+- Use block mined timeout instead of polling when waiting for transcation
+
+### Removed
+
+- Icon redunant polling code
+
+## [1.2.0] - 2024-04-09
+
+### Added
+
+- Full websocket listner support for all chains
+- Auto clean expired messages to avoid disk space issues
+
+### Changed
+
+- CallMessage is only retried twice to avoid spamming retries
+- Use only one websocket connection for maximum efficiency
+- Use `/event` active listener instead of block search leading to significant performance gains
+
+### Fixed
+
+- Error handling for the websocket connection
+- Start height for the icon chain
+- Manual relay for icon chain using the height (on chain)
+- Other improvements and bug fixes
+
+### Removed
+
+- Height sync is no longer necessary.
+
+## [1.1.3] - 2024-03-27
+
+### Added
+
+- Route manually from height (on chain)
+
+### Fixed
+
+- Increase delivery failure by trying for per 15 seconds after initial failures.
+- Panics when subscribing to the event result.
+- AWS ec2 instance profile detection.
+- Other improvements and bug fixes.
+
+## [1.1.2] - 2024-03-22
+
+### Fixed
+
+- Region detection for AWS
+- Priority 0 (high) for `start-height` evm
+- Panic too many packets map access
+
+## [1.1.1] - 2024-03-21
+
+### Added
+
+- Websocket support for evm chain
+
+### Fixed
+
+- AWS Region detection
+- Static binary build
+
 ## [1.1.0] - 2024-03-18
 
 ### Added
@@ -37,128 +148,3 @@ Exection will respect the fees set on configuration. The relay will now calculat
 Migrate keystore files to the new format by running the following command:
 
 **important**: Before running the command, make sure you have the AWS KMS key id. You can get the KMS key id by running the `crly config show` command.
-
-```shell
-aws kms encrypt --key-id <kms-key-id> --plaintext fileb://path/to/keystore.json --output text --query CiphertextBlob | base64 -d > path/to/keystore/address
-```
-
-Example when migrating the icon chain keystore file where its nid is `0x2.icon` and the wallet address is `0x0B958dd815195F73d6B9B91bFDF1639457678FEb`:
-
-verify keystore exists:
-
-```shell
-ls $HOME/.centralized-relay/keystore/0x2.icon/0x0B958dd815195F73d6B9B91bFDF1639457678FEb.json
-```
-
-Encrypt the keystore file:
-
-```shell
-aws kms encrypt --key-id <insert-key-id-here> --plaintext fileb://$HOME/.centralized-relay/keystore/0x2.icon/0x0B958dd815195F73d6B9B91bFDF1639457678FEb.json --output text --query CiphertextBlob | base64 -d > "$HOME/keystore/0x2.icon/0x0B958dd815195F73d6B9B91bFDF1639457678FEb"
-```
-
-Move the encrypted wallet passphrase to the new location:
-
-  ```shell
-  mv $HOME/keystore/0x2.icon/0x0B958dd815195F73d6B9B91bFDF1639457678FEb.password $HOME/.centralized relay/keystore/0x2.icon/0x0B958dd815195F73d6B9B91bFDF1639457678FEb.pass
-  ```
-
-### Additional Information
-
-- All the keystore relayer files are located in the `keystore` directory.
-  `ls $HOME/.centralized-relay/keystore`
-
-- The version `1.0.0` keystore files for chain are located in the inside the its `nid` directory in a following format:
-  `keystore/<nid>/<wallet-address>.json`
-
-## [1.1.1] - 2024-03-21
-
-### Added
-
-- Websocket support for evm chain
-
-### Fixed
-
-- AWS Region detection
-- Static binary build
-
-## [1.1.2] - 2024-03-22
-
-### Fixed
-
-- Region detection for AWS
-- Priority 0 (high) for `start-height` evm
-- Panic too many packets map access
-
-## [1.1.3] - 2024-03-27
-
-### Added
-
-- Route manually from height (on chain)
-
-### Fixed
-
-- Increase delivery failure by trying for per 15 seconds after initial failures.
-- Panics when subscribing to the event result.
-- AWS ec2 instance profile detection.
-- Other improvements and bug fixes.
-
-## [1.2.0] - 2024-04-09
-
-### Added
-
-- Full websocket listner support for all chains
-- Auto clean expired messages to avoid disk space issues
-
-### Changed
-
-- CallMessage is only retried twice to avoid spamming retries
-- Use only one websocket connection for maximum efficiency
-- Use `/event` active listener instead of block search leading to significant performance gains
-
-### Fixed
-
-- Error handling for the websocket connection
-- Start height for the icon chain
-- Manual relay for icon chain using the height (on chain)
-- Other improvements and bug fixes
-
-### Removed
-
-- Height sync is no longer necessary.
-
-## [1.2.1] - 2024-04-30
-
-### Fixed
-
-- Websocket connection disconnect issue with icon chain
-- Use `eth_gasPrice` for the gas price calculation all the time
-- Other improvements and bug fixes
-- Use block mined timeout instead of polling when waiting for transcation
-
-### Removed
-
-- Icon redunant polling code
-
-## [1.2.2] - 2024-05-01
-
-### Fixed
-
-- Avoid nonce increment when fixing the nonce error while sending the transaction
-
-# [1.2.3] - 2024-05-14
-
-### Added
-
-- Gas adjustment from config
-
-## [1.2.4] - 2024-05-17
-
-### Added
-
-- Support for the injective chain
-
-### Fixed
-
-- Gas Estimation for the evm chain
-- Cosmos sdk global config bech32 prefixes
-- Other improvements and bug fixes

--- a/relayer/chains/evm/provider.go
+++ b/relayer/chains/evm/provider.go
@@ -57,15 +57,16 @@ type Config struct {
 }
 
 type Provider struct {
-	client       IClient
-	log          *zap.Logger
-	cfg          *Config
-	StartHeight  uint64
-	blockReq     ethereum.FilterQuery
-	wallet       *keystore.Key
-	kms          kms.KMS
-	contracts    map[string]providerTypes.EventMap
-	NonceTracker types.NonceTrackerI
+	client              IClient
+	log                 *zap.Logger
+	cfg                 *Config
+	StartHeight         uint64
+	blockReq            ethereum.FilterQuery
+	wallet              *keystore.Key
+	kms                 kms.KMS
+	contracts           map[string]providerTypes.EventMap
+	NonceTracker        types.NonceTrackerI
+	LastSavedHeightFunc func() uint64
 }
 
 func (p *Config) NewProvider(ctx context.Context, log *zap.Logger, homepath string, debug bool, chainName string) (provider.ChainProvider, error) {
@@ -438,4 +439,14 @@ func (p *Provider) EstimateGas(ctx context.Context, message *providerTypes.Messa
 		contract = common.HexToAddress(p.cfg.Contracts[providerTypes.XcallContract])
 	}
 	return p.client.EstimateGas(ctx, msg)
+}
+
+// SetLastSavedBlockHeightFunc sets the function to save the last saved block height
+func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
+	p.LastSavedHeightFunc = f
+}
+
+// GetLastSavedBlockHeight returns the last saved block height
+func (p *Provider) GetLastSavedBlockHeight() uint64 {
+	return p.LastSavedHeightFunc()
 }

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -53,7 +53,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, incomin
 		Height:           types.NewHexInt(processedheight),
 		EventFilter:      p.GetMonitorEventFilters(),
 		Logs:             types.NewHexInt(1),
-		ProgressInterval: types.NewHexInt(15),
+		ProgressInterval: types.NewHexInt(25),
 	}
 
 	for {
@@ -76,7 +76,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, incomin
 								return err
 							}
 							if height > 0 {
-								eventReq.Height = types.NewHexInt(height + 1)
+								eventReq.Height = types.NewHexInt(height)
 							}
 							return nil
 						}
@@ -104,7 +104,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, incomin
 					if errors.Is(err, context.Canceled) {
 						return
 					}
-					time.Sleep(time.Second * 5)
+					time.Sleep(time.Second * 3)
 					reconnect()
 					p.log.Warn("error occured during monitor event", zap.Error(err))
 				}

--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -87,12 +87,13 @@ func (c *Config) Enabled() bool {
 }
 
 type Provider struct {
-	log       *zap.Logger
-	cfg       *Config
-	wallet    module.Wallet
-	client    *Client
-	kms       kms.KMS
-	contracts map[string]providerTypes.EventMap
+	log                 *zap.Logger
+	cfg                 *Config
+	wallet              module.Wallet
+	client              *Client
+	kms                 kms.KMS
+	contracts           map[string]providerTypes.EventMap
+	LastSavedHeightFunc func() uint64
 }
 
 func (p *Provider) NID() string {
@@ -257,4 +258,14 @@ func (p *Provider) ExecuteRollback(ctx context.Context, sn uint64) error {
 		return fmt.Errorf("failed: %s", txr.TxHash)
 	}
 	return nil
+}
+
+// SetLastSavedBlockHeightFunc sets the function to save the last saved block height
+func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
+	p.LastSavedHeightFunc = f
+}
+
+// GetLastSavedBlockHeight returns the last saved block height
+func (p *Provider) GetLastSavedBlockHeight() uint64 {
+	return p.LastSavedHeightFunc()
 }

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -33,6 +33,7 @@ type ChainProvider interface {
 	Route(ctx context.Context, message *types.Message, callback types.TxResponseFunc) error
 	ShouldReceiveMessage(ctx context.Context, message *types.Message) (bool, error)
 	ShouldSendMessage(ctx context.Context, message *types.Message) (bool, error)
+	SetLastSavedHeightFunc(func() uint64)
 	MessageReceived(ctx context.Context, key *types.MessageKey) (bool, error)
 	SetAdmin(context.Context, string) error
 

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -93,7 +93,9 @@ func NewRelayer(log *zap.Logger, db store.Store, chains map[string]*Chain, fresh
 			chainRuntime.LastSavedHeight = lastSavedHeight
 		}
 		chainRuntimes[chain.NID()] = chainRuntime
-
+		chainRuntime.Provider.SetLastSavedHeightFunc(func() uint64 {
+			return chainRuntime.LastSavedHeight
+		})
 	}
 
 	return &Relayer{

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -15,7 +15,7 @@ var (
 	XcallContract            = "xcall"
 	ConnectionContract       = "connection"
 	SupportedContracts       = []string{XcallContract, ConnectionContract}
-	RetryInterval            = 5 * time.Second
+	RetryInterval            = 3 * time.Second
 )
 
 type BlockInfo struct {
@@ -52,6 +52,14 @@ func (c ContractConfigMap) Validate() error {
 		}
 	}
 	return nil
+}
+
+// GetWasmMsgType returns the wasm message type
+func (m *EventMap) GetWasmMsgType() string {
+	for wasmType := range m.SigType {
+		return wasmType
+	}
+	return ""
 }
 
 func (m *Message) MessageKey() *MessageKey {


### PR DESCRIPTION
This pull request adds a fallback mechanism to switch to polling when the RPC fails. This ensures that the application can continue functioning even if the RPC connection is lost.