### PR TITLE
refactor: increase DefaultMinedTimeout to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this project will be documented in this file.
 - RPC failures are are handled more elegently, switches to the polling and back to the subscriptions
 - Other improvements and bug fixes
 
-### Refactor
+### Changed
 
 - Icon `progressInterval` notification block is not incremented to handle rpc failures
+- Default Block mined wait time is increased to 5 minutes
 
 ## [1.2.5] - 2024-05-18
 

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -23,7 +23,7 @@ import (
 const (
 	RPCCallRetry        = 5
 	MaxTxFixtures       = 5
-	DefaultMinedTimeout = time.Second * 60 * 5
+	DefaultMinedTimeout = time.Minute * 10
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -23,7 +23,7 @@ import (
 const (
 	RPCCallRetry        = 5
 	MaxTxFixtures       = 5
-	DefaultMinedTimeout = time.Second * 60
+	DefaultMinedTimeout = time.Second * 60 * 5
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {


### PR DESCRIPTION
This pull request increases the `DefaultMinedTimeout` value from 1 minute to 5 minutes in the `client.go` file. This change allows for a longer wait time for a block to be mined.