### PR TITLE
Refactor and fix relay functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - Cosmos contracts subscriptions respects the configured contracts
 - RPC failures are are handled more elegently, switches to the polling and back to the subscriptions
+- Address check validation for the manaul relay on the icon chain
 - Other improvements and bug fixes
 
 ### Changed
 
 - Icon `progressInterval` notification block is not incremented to handle rpc failures
-- Default Block mined wait time is increased to 5 minutes
+- Default Block mined wait time is increased to 10 minutes
+- Exponential backoff for the retry count
 
 ## [1.2.5] - 2024-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All notable changes to this project will be documented in this file.
 - RPC failures are are handled more elegently, switches to the polling and back to the subscriptions
 - Other improvements and bug fixes
 
-### Refactor
+### Changed
 
 - Icon `progressInterval` notification block is not incremented to handle rpc failures
+- Default Block mined wait time is increased to 5 minutes
 
 ## [1.2.5] - 2024-05-18
 

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -23,7 +23,7 @@ import (
 const (
 	RPCCallRetry        = 5
 	MaxTxFixtures       = 5
-	DefaultMinedTimeout = time.Second * 60 * 5
+	DefaultMinedTimeout = time.Minute * 10
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -23,7 +23,7 @@ import (
 const (
 	RPCCallRetry        = 5
 	MaxTxFixtures       = 5
-	DefaultMinedTimeout = time.Second * 60
+	DefaultMinedTimeout = time.Second * 60 * 5
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -21,7 +21,7 @@ var (
 	maxFlushMessage       uint = 10
 	FinalityInterval           = 5 * time.Second
 	DeleteExpiredInterval      = 6 * time.Hour
-	MessageExpiration          = 48 * time.Hour
+	MessageExpiration          = 24 * time.Hour
 
 	prefixMessageStore  = "message"
 	prefixBlockStore    = "block"

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"strings"
 	"sync"
@@ -103,7 +104,7 @@ func (r *RouteMessage) GetRetry() uint8 {
 
 // ResetLastTry resets the last try time to the current time plus the retry interval
 func (r *RouteMessage) AddNextTry() {
-	r.LastTry = time.Now().Add(RetryInterval)
+	r.LastTry = time.Now().Add(RetryInterval * time.Duration(math.Pow(2, float64(r.Retry)))) // exponential backoff
 }
 
 func (r *RouteMessage) IsProcessing() bool {


### PR DESCRIPTION
This pull request includes several changes to improve the relay functionality:

- Exponential backoff for retry count

- Decreased message retention period to 24 hours from 48 hours

- Address check validation for manual relay on the icon chain

- Changed default block mined wait time to 10 minutes

- Increased wait time for block to be mined

These changes aim to enhance the reliability and efficiency of the relay process.