### PR TITLE
refactor: transaction result handling

### DIFF
--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	RPCCallRetry        = 5
-	MaxTxFixtures       = 5
-	DefaultMinedTimeout = time.Minute * 10
+	RPCCallRetry           = 5
+	MaxTxFixtures          = 5
+	DefaultMinedTimeout    = time.Minute * 5
+	DefaultPollingInterval = time.Second * 5
+	MaximumWaitTry         = 60
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {

--- a/relayer/chains/evm/provider.go
+++ b/relayer/chains/evm/provider.go
@@ -175,11 +175,11 @@ func (p *Provider) FinalityBlock(ctx context.Context) uint64 {
 
 func (p *Provider) WaitForResults(ctx context.Context, tx *ethTypes.Transaction) (*coreTypes.Receipt, error) {
 	ticker := time.NewTicker(DefaultPollingInterval)
+	defer ticker.Stop()
 	counter := 0
 	ctx, cancel := context.WithTimeout(ctx, DefaultMinedTimeout)
 	defer cancel()
 	for {
-		defer ticker.Stop()
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()


### PR DESCRIPTION
This pull request refactors the code to use a custom method for handling transaction results. It also includes changes to the `DefaultMinedTimeout` and `DefaultPollingInterval` constants.

Trans. are mostly stuck at tx result polling. And offical sdk method is very aggresive. 

https://github.com/ethereum/go-ethereum/blob/35b2d07f4bf735958b41cd141a5feda5e61be73e/accounts/abi/bind/util.go#L32