### PR TITLE
Add changelog for version 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.7] - 2024-05-28
+
+### Fixed
+
+- Use on/off switch for the polling and subscriptions for recoveries
+- Other improvements and bug fixes
+
+### Changed
+
+- Evm block mined is replaced by custom function
+
 ## [1.2.6] - 2024-05-26
 
 ### Fixed


### PR DESCRIPTION
This pull request adds the changelog entry for version 1.2.7. It includes fixes for using an on/off switch for polling and subscriptions for recoveries, as well as other improvements and bug fixes. Additionally, it changes the Evm block mined to a custom function.