### PR TITLE
feat: add connection

### DIFF
--- a/example/configs/sui.json
+++ b/example/configs/sui.json
@@ -11,7 +11,6 @@
     "connection-id": "centralized-1",
     "connection-cap-id": "0x0bd3506ebbb37bb531342469c4665c3594442b6b004a8bb0e9910e5b04cc57ae",
     "dapp-package-id": "0x7d7ae28c5a82c0bdb17a106dbbb236e3ee94e4b12408f04a0a192b20273fb2fd",
-    "dapp-treasury-cap-carrier": "0x4e28f7b3765d7ae38cc85061d0998ef0d4240e8a01be58927d2c7854f07b14c7",
     "dapp-modules": [
       {
         "name": "xcall_manager",

--- a/example/configs/sui.json
+++ b/example/configs/sui.json
@@ -1,19 +1,32 @@
 {
   "type": "sui",
   "value": {
-    "chain-id": "sui",
-    "nid": "sui",
-    "rpc-url": "https://fullnode.devnet.sui.io:443",
+    "nid": "sui-test",
+    "rpc-url": "https://fullnode.testnet.sui.io:443",
     "address": "0x07304a5d7d1a4763a1cea91f478d24e40aecf1fdbd2f14764d5ad745f4904f85",
-    "xcall-package-id": "0xed18eec9609cf53e217993f5db388e25ee5b02d1e5efcc14d3ef75d1f4500e9a",
-    "xcall-storage-id": "0x753935d5f963ebdb506ce9dafcadc357122344e75c02a534d97a3c22c4fec4fd",
-    "dapp-package-id": "0xcc1af375dca0d4e6dcbbeb1821369c78d88808fccac2bfc42a185a562bd6765f",
-    "dapp-treasury-cap-carrier": "",
+    "xcall-package-ids": [
+      "0xd8acb58553eeefc32077075f4ee2a4dc7e9d65e0aa82639e12784043a0cffce1"
+    ],
+    "xcall-storage-id": "0x4655bb7859023e6a8804f31cb746999d9e0758da642aa8e7e18e11c31427c8cc",
+    "connection-id": "centralized-1",
+    "connection-cap-id": "0x0bd3506ebbb37bb531342469c4665c3594442b6b004a8bb0e9910e5b04cc57ae",
+    "dapp-package-id": "0x7d7ae28c5a82c0bdb17a106dbbb236e3ee94e4b12408f04a0a192b20273fb2fd",
+    "dapp-treasury-cap-carrier": "0x4e28f7b3765d7ae38cc85061d0998ef0d4240e8a01be58927d2c7854f07b14c7",
     "dapp-modules": [
       {
-        "name": "mock_dapp",
-        "cap-id": "b2686b2955bb0ef6b519c970a9cda2ad5326599e6772f6b004d2a580d6f17954",
-        "config-id": "0xd429175208e9aa327faf14dff06f9240a95f0b6fc1b8b00e81a20178f8a5a6ce"
+        "name": "xcall_manager",
+        "cap-id": "0xa4ea25a8025e04543408e0ad054321ae98fda932bdf4ee846ba60f6548d64bcb",
+        "config-id": "0x85df6e0d192cb6f54e0fcdf681f34323a83ed4be871059c897a69eb2a466a34b"
+      },
+      {
+        "name": "asset_manager",
+        "cap-id": "0xb31546a6f3a0fa3b265f0572113d6422e81ae7fa455a615d27d2cab8ef85ab93",
+        "config-id": "0xb5605a51dae249aecd7d70352cf36f589c11822568774c144909110ebd15ee02"
+      },
+      {
+        "name": "balanced_dollar",
+        "cap-id": "0x630d4a826c090023600498c562a7dd611ef673268b7a4bd7de63c571684d97cf",
+        "config-id": "0x2427b3a3b95600749848e69f694ddffef5f96b2a0cc03e3d56d8a8b83ce94826"
       }
     ],
     "gas-limit": 5000000

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -23,9 +23,8 @@ type Config struct {
 	ConnectionID    string `yaml:"connection-id" json:"connection-id"`
 	ConnectionCapID string `yaml:"connection-cap-id" json:"connection-cap-id"`
 
-	DappPkgID              string       `yaml:"dapp-package-id" json:"dapp-package-id"`
-	DappTreasuryCapCarrier string       `yaml:"dapp-treasury-cap-carrier" json:"dapp-treasury-cap-carrier"`
-	DappModules            []DappModule `yaml:"dapp-modules" json:"dapp-modules"`
+	DappPkgID   string       `yaml:"dapp-package-id" json:"dapp-package-id"`
+	DappModules []DappModule `yaml:"dapp-modules" json:"dapp-modules"`
 
 	HomeDir  string `yaml:"home-dir" json:"home-dir"`
 	GasLimit uint64 `yaml:"gas-limit" json:"gas-limit"`

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -20,6 +20,9 @@ type Config struct {
 	XcallPkgID     string `yaml:"xcall-package-id" json:"xcall-package-id"`
 	XcallStorageID string `yaml:"xcall-storage-id" json:"xcall-storage-id"`
 
+	ConnectionID    string `yaml:"connection-id" json:"connection-id"`
+	ConnectionCapID string `yaml:"connection-cap-id" json:"connection-cap-id"`
+
 	DappPkgID              string       `yaml:"dapp-package-id" json:"dapp-package-id"`
 	DappTreasuryCapCarrier string       `yaml:"dapp-treasury-cap-carrier" json:"dapp-treasury-cap-carrier"`
 	DappModules            []DappModule `yaml:"dapp-modules" json:"dapp-modules"`

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -17,8 +17,8 @@ type Config struct {
 	Address   string `yaml:"address" json:"address"`
 	NID       string `yaml:"nid" json:"nid"`
 
-	XcallPkgID     string `yaml:"xcall-package-id" json:"xcall-package-id"`
-	XcallStorageID string `yaml:"xcall-storage-id" json:"xcall-storage-id"`
+	XcallPkgIDs    []string `yaml:"xcall-package-ids" json:"xcall-package-ids"`
+	XcallStorageID string   `yaml:"xcall-storage-id" json:"xcall-storage-id"`
 
 	ConnectionID    string `yaml:"connection-id" json:"connection-id"`
 	ConnectionCapID string `yaml:"connection-cap-id" json:"connection-cap-id"`

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -162,6 +162,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		msg.Sn = uint64(sn)
 		msg.DappModuleCapID = rollbackMsgEvent.DappModuleCapId
 		msg.Dst = p.cfg.NID
+		msg.Data = rollbackMsgEvent.Data
 
 	default:
 		return nil, fmt.Errorf("invalid event type")

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -146,6 +146,19 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		msg.ReqID = uint64(reqID)
 		msg.DappModuleCapID = callMsgEvent.DappModuleCapId
 
+	case fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "RollbackMessage"):
+		msg.EventType = relayerEvents.ExecuteRollback
+		var rollbackMsgEvent types.RollbackMsgEvent
+		if err := json.Unmarshal(eventBytes, &rollbackMsgEvent); err != nil {
+			return nil, err
+		}
+		sn, err := strconv.Atoi(rollbackMsgEvent.Sn)
+		if err != nil {
+			return nil, err
+		}
+		msg.Sn = uint64(sn)
+		msg.DappModuleCapID = rollbackMsgEvent.DappModuleCapId
+
 	default:
 		return nil, fmt.Errorf("invalid event type")
 	}

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -25,6 +25,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedCheckpointSeq uint64, 
 	if lastSavedCheckpointSeq != 0 && lastSavedCheckpointSeq < latestCheckpointSeq {
 		startCheckpointSeq = lastSavedCheckpointSeq
 	}
+
 	return p.listenByPolling(ctx, startCheckpointSeq, blockInfo)
 }
 

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/icon-project/centralized-relay/relayer/chains/sui/types"
@@ -68,11 +69,15 @@ func (p *Provider) listenByPolling(ctx context.Context, startCheckpointSeq uint6
 }
 
 func (p *Provider) allowedEventTypes() []string {
-	return []string{
-		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleConnection, "Message"),
-		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "CallMessage"),
-		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "RollbackMessage"),
+	allowedEvents := []string{}
+	for _, xcallPkgId := range p.cfg.XcallPkgIDs {
+		allowedEvents = append(allowedEvents, []string{
+			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleConnection, "Message"),
+			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleMain, "CallMessage"),
+			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleMain, "RollbackMessage"),
+		}...)
 	}
+	return allowedEvents
 }
 
 func (p *Provider) parseMessagesFromEvents(events []types.EventResponse) ([]relayertypes.BlockInfo, error) {
@@ -119,8 +124,11 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		return nil, err
 	}
 
-	switch ev.Type {
-	case fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleConnection, "Message"):
+	eventParts := strings.Split(ev.Type, "::")
+	eventSuffix := strings.Join(eventParts[1:], "::")
+
+	switch eventSuffix {
+	case fmt.Sprintf("%s::%s", ModuleConnection, "Message"):
 		msg.EventType = relayerEvents.EmitMessage
 		var emitEvent types.EmitEvent
 		if err := json.Unmarshal(eventBytes, &emitEvent); err != nil {
@@ -134,7 +142,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		msg.Data = emitEvent.Msg
 		msg.Dst = emitEvent.To
 
-	case fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "CallMessage"):
+	case fmt.Sprintf("%s::%s", ModuleMain, "CallMessage"):
 		msg.EventType = relayerEvents.CallMessage
 		var callMsgEvent types.CallMsgEvent
 		if err := json.Unmarshal(eventBytes, &callMsgEvent); err != nil {
@@ -149,7 +157,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		msg.DappModuleCapID = callMsgEvent.DappModuleCapId
 		msg.Dst = p.cfg.NID
 
-	case fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "RollbackMessage"):
+	case fmt.Sprintf("%s::%s", ModuleMain, "RollbackMessage"):
 		msg.EventType = relayerEvents.ExecuteRollback
 		var rollbackMsgEvent types.RollbackMsgEvent
 		if err := json.Unmarshal(eventBytes, &rollbackMsgEvent); err != nil {

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -68,8 +68,9 @@ func (p *Provider) listenByPolling(ctx context.Context, startCheckpointSeq uint6
 
 func (p *Provider) allowedEventTypes() []string {
 	return []string{
-		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, "centralized_connection", "Message"),
-		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, "main", "CallMessage"),
+		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleConnection, "Message"),
+		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "CallMessage"),
+		fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "RollbackMessage"),
 	}
 }
 
@@ -145,6 +146,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		}
 		msg.ReqID = uint64(reqID)
 		msg.DappModuleCapID = callMsgEvent.DappModuleCapId
+		msg.Dst = p.cfg.NID
 
 	case fmt.Sprintf("%s::%s::%s", p.cfg.XcallPkgID, ModuleMain, "RollbackMessage"):
 		msg.EventType = relayerEvents.ExecuteRollback
@@ -158,6 +160,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 		}
 		msg.Sn = uint64(sn)
 		msg.DappModuleCapID = rollbackMsgEvent.DappModuleCapId
+		msg.Dst = p.cfg.NID
 
 	default:
 		return nil, fmt.Errorf("invalid event type")

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -209,6 +209,7 @@ func (p *Provider) GetFee(ctx context.Context, networkID string, responseFee boo
 		[]string{},
 		[]SuiCallArg{
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
+			{Type: CallArgPure, Val: p.cfg.ConnectionID},
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: responseFee},
 		}, p.cfg.XcallPkgID, ModuleEntry, MethodGetFee)
@@ -232,6 +233,7 @@ func (p *Provider) SetFee(ctx context.Context, networkID string, msgFee, resFee 
 		[]string{},
 		[]SuiCallArg{
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
+			{Type: CallArgObject, Val: p.cfg.ConnectionCapID},
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: strconv.Itoa(int(msgFee))},
 			{Type: CallArgPure, Val: strconv.Itoa(int(resFee))},
@@ -256,6 +258,7 @@ func (p *Provider) ClaimFee(ctx context.Context) error {
 		[]string{},
 		[]SuiCallArg{
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
+			{Type: CallArgObject, Val: p.cfg.ConnectionCapID},
 		},
 		p.cfg.XcallPkgID, ModuleEntry, MethodClaimFee)
 	txBytes, err := p.prepareTxMoveCall(suiMessage)

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -25,6 +25,7 @@ var (
 	MethodGetAdmin             = "get_admin"
 	MethodRecvMessage          = "receive_message"
 	MethodExecuteCall          = "execute_call"
+	MethodExecuteRollback      = "execute_rollback"
 	MethodGetWithdrawTokentype = "get_withdraw_token_type"
 
 	ModuleConnection = "centralized_connection"

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -36,7 +36,7 @@ var (
 	ModuleMockDapp       = "mock_dapp"
 	ModuleXcallManager   = "xcall_manager"
 	ModuleAssetManager   = "asset_manager"
-	ModuleBalancedDollar = "balanced_dollar"
+	ModuleBalancedDollar = "balanced_dollar_crosschain"
 
 	suiCurrencyDenom = "SUI"
 	suiBaseFee       = 1000

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -2,12 +2,12 @@ package sui
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"strconv"
 	"sync"
 
 	"github.com/coming-chat/go-sui/v2/account"
-	"github.com/coming-chat/go-sui/v2/move_types"
 	"github.com/icon-project/centralized-relay/relayer/chains/sui/types"
 	"github.com/icon-project/centralized-relay/relayer/kms"
 	"github.com/icon-project/centralized-relay/relayer/provider"
@@ -141,67 +141,13 @@ func (p *Provider) GenerateMessages(ctx context.Context, messageKey *relayertype
 
 // SetAdmin transfers the ownership of sui connection module to new address
 func (p *Provider) SetAdmin(ctx context.Context, adminAddr string) error {
-	suiMessage := p.NewSuiMessage(
-		[]string{},
-		[]SuiCallArg{
-			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
-			{Type: CallArgPure, Val: adminAddr},
-		}, p.cfg.XcallPkgID, ModuleEntry, MethodSetAdmin)
-
-	txBytes, err := p.prepareTxMoveCall(suiMessage)
-	if err != nil {
-		return err
-	}
-	res, err := p.SendTransaction(ctx, txBytes)
-	if err != nil {
-		return err
-	}
-	p.log.Info("set fee txn successful",
-		zap.String("tx-hash", res.Digest.String()),
-	)
-	return nil
+	//implementation not needed in sui
+	return fmt.Errorf("set_admin is not implmented in sui contract")
 }
 
 func (p *Provider) RevertMessage(ctx context.Context, sn *big.Int) error {
-	suiMessage := p.NewSuiMessage(
-		[]string{},
-		[]SuiCallArg{
-			{Type: CallArgPure, Val: sn},
-		}, p.cfg.XcallPkgID, ModuleEntry, MethodRevertMessage)
-	txBytes, err := p.prepareTxMoveCall(suiMessage)
-	if err != nil {
-		return err
-	}
-	res, err := p.SendTransaction(ctx, txBytes)
-	if err != nil {
-		return err
-	}
-	p.log.Info("revert message txn successful",
-		zap.String("tx-hash", res.Digest.String()),
-	)
-	return nil
-}
-
-func (p *Provider) GetAdmin(ctx context.Context, networkID string, responseFee bool) (uint64, error) {
-	suiMessage := p.NewSuiMessage(
-		[]string{},
-		[]SuiCallArg{
-			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
-		}, p.cfg.XcallPkgID, ModuleEntry, "get_admin")
-	var adminAddr move_types.AccountAddress
-	wallet, err := p.Wallet()
-	if err != nil {
-		return 0, err
-	}
-	txBytes, err := p.preparePTB(suiMessage)
-	if err != nil {
-		return 0, err
-	}
-	if err := p.client.QueryContract(ctx, wallet.Address, txBytes, &adminAddr); err != nil {
-		return 0, err
-	}
-
-	return 0, nil
+	//implementation not needed in sui
+	return fmt.Errorf("revert_message is not implemented in sui contract")
 }
 
 func (p *Provider) GetFee(ctx context.Context, networkID string, responseFee bool) (uint64, error) {

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -158,7 +158,7 @@ func (p *Provider) GetFee(ctx context.Context, networkID string, responseFee boo
 			{Type: CallArgPure, Val: p.cfg.ConnectionID},
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: responseFee},
-		}, p.cfg.XcallPkgID, ModuleEntry, MethodGetFee)
+		}, p.xcallPkgIDLatest(), ModuleEntry, MethodGetFee)
 	var fee uint64
 	wallet, err := p.Wallet()
 	if err != nil {
@@ -183,7 +183,7 @@ func (p *Provider) SetFee(ctx context.Context, networkID string, msgFee, resFee 
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: strconv.Itoa(int(msgFee))},
 			{Type: CallArgPure, Val: strconv.Itoa(int(resFee))},
-		}, p.cfg.XcallPkgID, ModuleEntry, MethodSetFee)
+		}, p.xcallPkgIDLatest(), ModuleEntry, MethodSetFee)
 	txBytes, err := p.prepareTxMoveCall(suiMessage)
 	if err != nil {
 		return err
@@ -206,7 +206,7 @@ func (p *Provider) ClaimFee(ctx context.Context) error {
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
 			{Type: CallArgObject, Val: p.cfg.ConnectionCapID},
 		},
-		p.cfg.XcallPkgID, ModuleEntry, MethodClaimFee)
+		p.xcallPkgIDLatest(), ModuleEntry, MethodClaimFee)
 	txBytes, err := p.prepareTxMoveCall(suiMessage)
 	if err != nil {
 		return err
@@ -235,4 +235,8 @@ func (p *Provider) ShouldReceiveMessage(ctx context.Context, messagekey *relayer
 
 func (p *Provider) ShouldSendMessage(ctx context.Context, messageKey *relayertypes.Message) (bool, error) {
 	return true, nil
+}
+
+func (p *Provider) xcallPkgIDLatest() string {
+	return p.cfg.XcallPkgIDs[0]
 }

--- a/relayer/chains/sui/provider_test.go
+++ b/relayer/chains/sui/provider_test.go
@@ -5,13 +5,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/coming-chat/go-sui/v2/account"
 	"github.com/coming-chat/go-sui/v2/lib"
 	"github.com/coming-chat/go-sui/v2/types"
-	"github.com/fardream/go-bcs/bcs"
 	suitypes "github.com/icon-project/centralized-relay/relayer/chains/sui/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -272,20 +270,4 @@ func TestGenerateTxDigests(t *testing.T) {
 			assert.Equal(subTest, eachTest.expectedOutput, p.GenerateTxDigests(eachTest.input, maxDigests))
 		})
 	}
-}
-
-func TestEncodeBCSByteArray(t *testing.T) {
-	hexStr := "f89c8a5769746864726177546fb84a303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030323a3a7375693a3a535549b84230786566396432393635326639623236343831626662373664643931383930353736396661623134663165633363623863303464383834376664356232323364336264"
-	hexByte, _ := hex.DecodeString(hexStr)
-
-	bcsBytes, _ := bcs.Marshal(hexByte)
-
-	hexBcs := hex.EncodeToString(bcsBytes)
-
-	resultStrList := strings.Split(hexBcs, hexStr)
-
-	fmt.Println("Prefix: ", resultStrList[0])
-
-	fmt.Println("Lenght of hexbyte:", len(hexByte))
-	fmt.Println("Lenght of hexbcs:", len(bcsBytes))
 }

--- a/relayer/chains/sui/provider_test.go
+++ b/relayer/chains/sui/provider_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/coming-chat/go-sui/v2/account"
 	"github.com/coming-chat/go-sui/v2/lib"
 	"github.com/coming-chat/go-sui/v2/types"
+	"github.com/fardream/go-bcs/bcs"
 	suitypes "github.com/icon-project/centralized-relay/relayer/chains/sui/types"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -270,4 +272,20 @@ func TestGenerateTxDigests(t *testing.T) {
 			assert.Equal(subTest, eachTest.expectedOutput, p.GenerateTxDigests(eachTest.input, maxDigests))
 		})
 	}
+}
+
+func TestEncodeBCSByteArray(t *testing.T) {
+	hexStr := "f89c8a5769746864726177546fb84a303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030323a3a7375693a3a535549b84230786566396432393635326639623236343831626662373664643931383930353736396661623134663165633363623863303464383834376664356232323364336264"
+	hexByte, _ := hex.DecodeString(hexStr)
+
+	bcsBytes, _ := bcs.Marshal(hexByte)
+
+	hexBcs := hex.EncodeToString(bcsBytes)
+
+	resultStrList := strings.Split(hexBcs, hexStr)
+
+	fmt.Println("Prefix: ", resultStrList[0])
+
+	fmt.Println("Lenght of hexbyte:", len(hexByte))
+	fmt.Println("Lenght of hexbcs:", len(bcsBytes))
 }

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -136,7 +136,6 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 				return nil, fmt.Errorf("failed to find xcall manager module: %w", err)
 			}
 			callParams = []SuiCallArg{
-				{Type: CallArgObject, Val: p.cfg.DappTreasuryCapCarrier},
 				{Type: CallArgObject, Val: module.ConfigID},
 				{Type: CallArgObject, Val: xcallManagerModule.ConfigID},
 				{Type: CallArgObject, Val: p.cfg.XcallStorageID},
@@ -190,7 +189,6 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 			}
 		case ModuleBalancedDollar:
 			callParams = []SuiCallArg{
-				{Type: CallArgObject, Val: p.cfg.DappTreasuryCapCarrier},
 				{Type: CallArgObject, Val: module.ConfigID},
 				{Type: CallArgObject, Val: p.cfg.XcallStorageID},
 				{Type: CallArgPure, Val: snU128},

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -179,6 +179,8 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 				return nil, fmt.Errorf("failed to get withdraw token type: %w", err)
 			}
 
+			p.log.Info("Withdraw Token Type Successful", zap.String("token-type", *withdrawTokenType))
+
 			typeArgs = append(typeArgs, *withdrawTokenType)
 
 			callParams = []SuiCallArg{

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -62,7 +62,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 			{Type: CallArgPure, Val: snU128},
 			{Type: CallArgPure, Val: "0x" + hex.EncodeToString(message.Data)},
 		}
-		return p.NewSuiMessage([]string{}, callParams, p.cfg.XcallPkgID, ModuleEntry, MethodRecvMessage), nil
+		return p.NewSuiMessage([]string{}, callParams, p.xcallPkgIDLatest(), ModuleEntry, MethodRecvMessage), nil
 	case events.CallMessage:
 		if _, err := p.Wallet(); err != nil {
 			return nil, err
@@ -466,7 +466,7 @@ func (p *Provider) MessageReceived(ctx context.Context, key *relayertypes.Messag
 			{Type: CallArgPure, Val: p.cfg.ConnectionID},
 			{Type: CallArgPure, Val: key.Src},
 			{Type: CallArgPure, Val: snU128},
-		}, p.cfg.XcallPkgID, ModuleEntry, MethodGetReceipt)
+		}, p.xcallPkgIDLatest(), ModuleEntry, MethodGetReceipt)
 	var msgReceived bool
 	wallet, err := p.Wallet()
 	if err != nil {

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -180,8 +180,6 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 				return nil, fmt.Errorf("failed to get withdraw token type: %w", err)
 			}
 
-			p.log.Info("Withdraw Token Type Successful", zap.String("token-type", *withdrawTokenType))
-
 			typeArgs = append(typeArgs, *withdrawTokenType)
 
 			callParams = []SuiCallArg{

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -57,6 +57,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 		}
 		callParams := []SuiCallArg{
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
+			{Type: CallArgObject, Val: p.cfg.ConnectionCapID},
 			{Type: CallArgPure, Val: message.Src},
 			{Type: CallArgPure, Val: snU128},
 			{Type: CallArgPure, Val: "0x" + hex.EncodeToString(message.Data)},
@@ -462,6 +463,7 @@ func (p *Provider) MessageReceived(ctx context.Context, key *relayertypes.Messag
 		[]string{},
 		[]SuiCallArg{
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
+			{Type: CallArgPure, Val: p.cfg.ConnectionID},
 			{Type: CallArgPure, Val: key.Src},
 			{Type: CallArgPure, Val: snU128},
 		}, p.cfg.XcallPkgID, ModuleEntry, MethodGetReceipt)

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -108,11 +108,12 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 				return mod.Name == ModuleXcallManager
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to find xcall manager module")
+				return nil, fmt.Errorf("failed to find xcall manager module: %w", err)
 			}
+
 			withdrawTokenType, err := p.getWithdrawTokentype(context.Background(), message)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get withdraw token type")
+				return nil, fmt.Errorf("failed to get withdraw token type: %w", err)
 			}
 
 			typeArgs = append(typeArgs, *withdrawTokenType)
@@ -131,7 +132,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 				return mod.Name == ModuleXcallManager
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to find xcall manager module")
+				return nil, fmt.Errorf("failed to find xcall manager module: %w", err)
 			}
 			callParams = []SuiCallArg{
 				{Type: CallArgObject, Val: p.cfg.DappTreasuryCapCarrier},
@@ -175,7 +176,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 		case ModuleAssetManager:
 			withdrawTokenType, err := p.getWithdrawTokentype(context.Background(), message)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get withdraw token type")
+				return nil, fmt.Errorf("failed to get withdraw token type: %w", err)
 			}
 
 			typeArgs = append(typeArgs, *withdrawTokenType)
@@ -484,7 +485,7 @@ func (p *Provider) getWithdrawTokentype(ctx context.Context, message *relayertyp
 	suiMessage := p.NewSuiMessage(
 		[]string{},
 		[]SuiCallArg{
-			{Type: CallArgPure, Val: "0x" + hex.EncodeToString(message.Data)},
+			{Type: CallArgPure, Val: message.Data},
 		}, p.cfg.DappPkgID, ModuleAssetManager, MethodGetWithdrawTokentype)
 	var tokenType string
 	wallet, err := p.Wallet()

--- a/relayer/chains/sui/types/types.go
+++ b/relayer/chains/sui/types/types.go
@@ -9,6 +9,8 @@ const (
 	XcallContract      = "xcall"
 	ConnectionContract = "connection"
 
+	ConnectionIDMismatchError = "connection_id_mismatch_error"
+
 	QUERY_MAX_RESULT_LIMIT = 50
 )
 
@@ -66,9 +68,10 @@ type SuiMultiGetTransactionBlocksRequest struct {
 }
 
 type EmitEvent struct {
-	Sn  string `json:"conn_sn"`
-	Msg []byte `json:"msg"`
-	To  string `json:"to"`
+	Sn           string `json:"conn_sn"`
+	Msg          []byte `json:"msg"`
+	To           string `json:"to"`
+	ConnectionID string `json:"connection_id"`
 }
 
 type CallMsgEvent struct {

--- a/relayer/chains/sui/types/types.go
+++ b/relayer/chains/sui/types/types.go
@@ -79,5 +79,6 @@ type CallMsgEvent struct {
 
 type RollbackMsgEvent struct {
 	Sn              string `json:"sn"`
+	Data            []byte `json:"data"`
 	DappModuleCapId string `json:"dapp"`
 }

--- a/relayer/chains/sui/types/types.go
+++ b/relayer/chains/sui/types/types.go
@@ -76,3 +76,8 @@ type CallMsgEvent struct {
 	Data            []byte `json:"data"`
 	DappModuleCapId string `json:"to"`
 }
+
+type RollbackMsgEvent struct {
+	Sn              string `json:"sn"`
+	DappModuleCapId string `json:"dapp"`
+}

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -252,6 +252,12 @@ func (r *Relayer) processMessages(ctx context.Context) {
 					message.ToggleProcessing()
 					go r.ExecuteCall(ctx, message, src)
 				}
+
+			case events.ExecuteRollback:
+				if !message.IsProcessing() {
+					message.ToggleProcessing()
+					go r.ExecuteRollback(ctx, message, src)
+				}
 			}
 		}
 	}
@@ -365,6 +371,35 @@ func (r *Relayer) ExecuteCall(ctx context.Context, msg *types.RouteMessage, dst 
 		r.HandleMessageFailed(routeMessage, dst, dst)
 	}
 	msg.IncrementRetry()
+	if err := dst.Provider.Route(ctx, msg.Message, callback); err != nil {
+		dst.log.Error("error occured during message route", zap.Error(err))
+		r.HandleMessageFailed(msg, dst, dst)
+	}
+}
+
+// ExecuteRollback
+func (r *Relayer) ExecuteRollback(ctx context.Context, msg *types.RouteMessage, dst *ChainRuntime) {
+	callback := func(key *types.MessageKey, response *types.TxResponse, err error) {
+		if response.Code == types.Success {
+			dst.log.Info("message relayed successfully",
+				zap.String("dst", dst.Provider.NID()),
+				zap.String("tx_hash", response.TxHash),
+				zap.Uint64("sn", key.Sn),
+				zap.String("event_type", msg.EventType),
+				zap.Int64("height", response.Height),
+			)
+			if err := r.ClearMessages(ctx, []*types.MessageKey{key}, dst); err != nil {
+				r.log.Error("error occured when clearing successful message", zap.Error(err))
+			}
+			return
+		}
+		routeMessage, ok := dst.MessageCache.Get(key)
+		if !ok {
+			r.log.Error("key not found in messageCache", zap.Any("key", &key))
+			return
+		}
+		r.HandleMessageFailed(routeMessage, dst, dst)
+	}
 	if err := dst.Provider.Route(ctx, msg.Message, callback); err != nil {
 		dst.log.Error("error occured during message route", zap.Error(err))
 		r.HandleMessageFailed(msg, dst, dst)


### PR DESCRIPTION
- Added centralized connection cap and ID in sui contract calls to allow messages only from specific connection id.
- Removed implementations of contract calls: set_admin and revert_message, because these are not needed in case of sui.
- Added support for event listener from multiple xcall packages because on every package upgrade in SUI new packageID is created and if new event is added in the upgrade we need to listen to that package id as well.