### PR TITLE
fix: icon ws error and use plain http rpc

### DIFF
--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -27,12 +27,17 @@ func newClient(ctx context.Context, connectionContract, XcallContract common.Add
 		return nil, err
 	}
 
-	connection, err := bridgeContract.NewConnection(connectionContract, eth)
+	ethRpc, err := ethclient.DialContext(ctx, rpcUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	connection, err := bridgeContract.NewConnection(connectionContract, ethRpc)
 	if err != nil {
 		return nil, fmt.Errorf("error occured when creating connection cobtract: %v ", err)
 	}
 
-	xcall, err := bridgeContract.NewXcall(XcallContract, eth)
+	xcall, err := bridgeContract.NewXcall(XcallContract, ethRpc)
 	if err != nil {
 		return nil, fmt.Errorf("error occured when creating eth client: %v ", err)
 	}

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -59,6 +59,11 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 		resetFunc      = func() {
 			isSubError = true
 			subscribeStart.Reset(time.Second * 3)
+			client, err := p.client.Reconnect()
+			if err != nil {
+				p.log.Error("failed to reconnect", zap.Error(err))
+			}
+			p.client = client
 		}
 	)
 

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -62,8 +62,9 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 			client, err := p.client.Reconnect()
 			if err != nil {
 				p.log.Error("failed to reconnect", zap.Error(err))
+			} else {
+				p.client = client
 			}
-			p.client = client
 		}
 	)
 
@@ -107,11 +108,13 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 							Addresses: p.blockReq.Addresses,
 							Topics:    p.blockReq.Topics,
 						}
+						p.log.Info("syncing", zap.Uint64("start", br.start), zap.Uint64("end", br.end), zap.Uint64("latest", latestHeight))
 						logs, err := p.getLogsRetry(ctx, filter, br.retry)
 						if err != nil {
 							p.log.Warn("failed to fetch blocks", zap.Uint64("from", br.start), zap.Uint64("to", br.end), zap.Error(err))
 							continue
 						}
+						p.log.Info("synced", zap.Uint64("start", br.start), zap.Uint64("end", br.end), zap.Uint64("latest", latestHeight))
 						for _, log := range logs {
 							message, err := p.getRelayMessageFromLog(log)
 							if err != nil {

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -58,7 +58,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 		concurrency    = p.GetConcurrency(ctx, startHeight, latestHeight)
 		resetFunc      = func() {
 			isSubError = true
-			subscribeStart.Reset(time.Second * 3)
+			subscribeStart.Reset(time.Second * 1)
 			client, err := p.client.Reconnect()
 			if err != nil {
 				p.log.Error("failed to reconnect", zap.Error(err))
@@ -253,8 +253,6 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 				Messages: []*relayertypes.Message{message},
 			}
 		case <-time.After(time.Minute * 2):
-			ctx, cancel := context.WithTimeout(ctx, defaultReadTimeout)
-			defer cancel()
 			if _, err := p.client.GetHeaderByHeight(ctx, big.NewInt(1)); err != nil {
 				p.log.Error("connection error", zap.Error(err))
 				resetFunc()

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -82,13 +82,9 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 			}
 
 			var blockReqs []*blockReq
-			for i := startHeight; i < latestHeight; i += p.cfg.BlockBatchSize {
-				end := i + p.cfg.BlockBatchSize
-				if end > latestHeight {
-					end = latestHeight
-				}
-				blockReqs = append(blockReqs, &blockReq{start: i, end: end, retry: maxBlockQueryFailedRetry})
-				i = end + 1
+			for start := startHeight; start <= latestHeight; start += p.cfg.BlockBatchSize {
+				end := min(start+p.cfg.BlockBatchSize-1, latestHeight)
+				blockReqs = append(blockReqs, &blockReq{start, end, nil, maxBlockQueryFailedRetry})
 			}
 			totalReqs := len(blockReqs)
 			// Calculate the size of each chunk

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -256,7 +256,9 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 				Height:   log.BlockNumber,
 				Messages: []*relayertypes.Message{message},
 			}
-		case <-time.After(time.Minute):
+		case <-time.After(time.Minute * 2):
+			ctx, cancel := context.WithTimeout(ctx, defaultReadTimeout)
+			defer cancel()
 			if _, err := p.client.GetHeaderByHeight(ctx, big.NewInt(1)); err != nil {
 				p.log.Error("connection error", zap.Error(err))
 				resetFunc()

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -256,6 +256,12 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 				Height:   log.BlockNumber,
 				Messages: []*relayertypes.Message{message},
 			}
+		case <-time.After(time.Minute):
+			if _, err := p.client.GetHeaderByHeight(ctx, big.NewInt(1)); err != nil {
+				p.log.Error("connection error", zap.Error(err))
+				resetFunc()
+				return err
+			}
 		}
 	}
 }

--- a/relayer/chains/icon/client.go
+++ b/relayer/chains/icon/client.go
@@ -265,12 +265,13 @@ func (c *Client) Monitor(ctx context.Context, reqUrl string, reqPtr, respPtr int
 		return err
 	}
 	defer func() {
-		c.log.Debug(fmt.Sprintf("Monitor finish %s", conn.LocalAddr().String()))
+		c.log.Debug(fmt.Sprintf("Monitor finish %s", conn.RemoteAddr().String()))
 		c.wsClose(conn)
 	}()
 	if err = c.wsRequest(conn, reqPtr); err != nil {
 		return err
 	}
+	c.log.Info("Monitoring started", zap.String("address", conn.RemoteAddr().String()))
 	conn.SetPongHandler(func(string) error {
 		return conn.SetReadDeadline(time.Now().Add(15 * time.Second))
 	})

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -102,6 +102,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, incomin
 					if errors.Is(err, context.Canceled) {
 						return
 					}
+					eventReq.Height = types.NewHexInt(int64(p.GetLastSavedBlockHeight()))
 					time.Sleep(time.Second * 3)
 					reconnect()
 					p.log.Warn("error occured during monitor event", zap.Error(err))

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -225,8 +225,7 @@ func (r *Relayer) processMessages(ctx context.Context) {
 				}
 
 				if ok := dst.shouldSendMessage(ctx, message, src); !ok {
-					// debug log
-					r.log.Debug("message not sent to destination", zap.Any("message", message))
+					r.log.Debug("processing", zap.Any("message", message))
 					continue
 				}
 
@@ -235,7 +234,7 @@ func (r *Relayer) processMessages(ctx context.Context) {
 				// if message reached delete the message
 				messageReceived, err := dst.Provider.MessageReceived(ctx, &key)
 				if err != nil {
-					dst.log.Error("error occured when checking message received", zap.Error(err))
+					dst.log.Error("error occured when checking message received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()), zap.Error(err))
 					message.ToggleProcessing()
 					continue
 				}


### PR DESCRIPTION
Icon goes back to last saved height for ws error instead of progress interval.

EVM now uses http rpc to mitigate ws connection failures