### PR TITLE
fix: query latest height when subscription errors occur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.9] - 2024-06-19
+
+### Added
+
+- Use gas price cap and gas tip for the evm chain
+
+### Fixed
+
+- Use pending nonce instead of the latest nonce for the evm chain
+- Other improvements and bug fixes
+- CPU and memeory usage optimization, dropped by more than 100%
+- Retry is more stable
+- Exponential backoff for the retry count
+
+### Changed
+
+- mutext on router
+- evm past polling for events is optimized, it can batch call now using config option
+- cosmwasm block polling using batch size using config option
+
+## [1.2.8] - 2024-06-06
+
+### Changed
+
+- Removed concurrency
+
 ## [1.2.7] - 2024-05-28
 
 ### Fixed

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -53,19 +53,9 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 
 	var (
 		subscribeStart = time.NewTicker(time.Second * 1)
-		isSubError     bool
 		latestHeight   = p.latestHeight(ctx)
 		concurrency    = p.GetConcurrency(ctx, startHeight, latestHeight)
-		resetFunc      = func() {
-			isSubError = true
-			subscribeStart.Reset(time.Second * 1)
-			client, err := p.client.Reconnect()
-			if err != nil {
-				p.log.Error("failed to reconnect", zap.Error(err))
-			} else {
-				p.client = client
-			}
-		}
+		resetChannel   = make(chan struct{})
 	)
 
 	for {
@@ -73,13 +63,19 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 		case <-ctx.Done():
 			p.log.Debug("evm listener: done")
 			return nil
+		case <-resetChannel:
+			startHeight = p.GetLastSavedBlockHeight()
+			latestHeight = p.latestHeight(ctx)
+			subscribeStart.Reset(time.Second * 1)
+			client, err := p.client.Reconnect()
+			if err != nil {
+				p.log.Error("failed to reconnect", zap.Error(err))
+			} else {
+				p.client = client
+			}
 		case <-subscribeStart.C:
 			subscribeStart.Stop()
-			go p.Subscribe(ctx, blockInfoChan, resetFunc)
-
-			if isSubError {
-				startHeight = p.GetLastSavedBlockHeight()
-			}
+			go p.Subscribe(ctx, blockInfoChan, resetChannel)
 
 			var blockReqs []*blockReq
 			for start := startHeight; start <= latestHeight; start += p.cfg.BlockBatchSize {
@@ -213,7 +209,7 @@ func (p *Provider) startFromHeight(ctx context.Context, lastSavedHeight uint64) 
 }
 
 // Subscribe listens to new blocks and sends them to the channel
-func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertypes.BlockInfo, resetFunc func()) error {
+func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertypes.BlockInfo, resetCh chan struct{}) error {
 	ch := make(chan ethTypes.Log, 10)
 	sub, err := p.client.Subscribe(ctx, ethereum.FilterQuery{
 		Addresses: p.blockReq.Addresses,
@@ -221,7 +217,7 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 	}, ch)
 	if err != nil {
 		p.log.Error("failed to subscribe", zap.Error(err))
-		resetFunc()
+		resetCh <- struct{}{}
 		return err
 	}
 	defer sub.Unsubscribe()
@@ -233,7 +229,7 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 			return nil
 		case err := <-sub.Err():
 			p.log.Error("subscription error", zap.Error(err))
-			resetFunc()
+			resetCh <- struct{}{}
 			return err
 		case log := <-ch:
 			message, err := p.getRelayMessageFromLog(log)
@@ -255,7 +251,7 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 		case <-time.After(time.Minute * 2):
 			if _, err := p.client.GetHeaderByHeight(ctx, big.NewInt(1)); err != nil {
 				p.log.Error("connection error", zap.Error(err))
-				resetFunc()
+				resetCh <- struct{}{}
 				return err
 			}
 		}

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -66,6 +66,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 		case <-resetChannel:
 			startHeight = p.GetLastSavedBlockHeight()
 			latestHeight = p.latestHeight(ctx)
+			concurrency = p.GetConcurrency(ctx, startHeight, latestHeight)
 			subscribeStart.Reset(time.Second * 1)
 			client, err := p.client.Reconnect()
 			if err != nil {

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -67,13 +67,13 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 			startHeight = p.GetLastSavedBlockHeight()
 			latestHeight = p.latestHeight(ctx)
 			concurrency = p.GetConcurrency(ctx, startHeight, latestHeight)
-			subscribeStart.Reset(time.Second * 1)
 			client, err := p.client.Reconnect()
 			if err != nil {
 				p.log.Error("failed to reconnect", zap.Error(err))
 			} else {
 				p.client = client
 			}
+			subscribeStart.Reset(time.Second * 1)
 		case <-subscribeStart.C:
 			subscribeStart.Stop()
 			go p.Subscribe(ctx, blockInfoChan, resetChannel)


### PR DESCRIPTION
This pull request fixes an issue where the latest height was not being queried correctly when subscription errors occurred. The `resetFunc` function has been replaced with a `resetChannel` to handle the reconnection logic. This ensures that the latest height is correctly retrieved and the subscription is restarted when errors occur.