### PR TITLE
fix: return error for relay handeFailed

### DIFF
--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -147,7 +147,7 @@ func (p *Provider) WaitForTxResult(
 	// assign tx successful height
 	res.Height = height
 
-	if status, err := txRes.Status.Int(); status != 1 {
+	if status, err := txRes.Status.Int(); status != 1 || err != nil {
 		err = fmt.Errorf("error: %s", err)
 		callback(messageKey, res, err)
 		p.LogFailedTx(method, txRes, err)

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -162,8 +162,7 @@ func (p *Provider) Route(ctx context.Context, message *relayTypes.Message, callb
 	if err := p.wallet.SetSequence(seq); err != nil {
 		p.logger.Error("failed to set sequence", zap.Error(err))
 	}
-	p.waitForTxResult(ctx, message.MessageKey(), res.TxHash, callback)
-	return nil
+	return p.waitForTxResult(ctx, message.MessageKey(), res, callback)
 }
 
 // call the smart contract to send the message
@@ -218,18 +217,18 @@ func (p *Provider) handleSequence(ctx context.Context) error {
 	return p.wallet.SetSequence(acc.GetSequence())
 }
 
-func (p *Provider) logTxFailed(err error, txHash string, code relayTypes.ResponseCode) {
+func (p *Provider) logTxFailed(err error, tx *sdkTypes.TxResponse) {
 	p.logger.Error("transaction failed",
+		zap.String("tx_hash", tx.TxHash),
+		zap.String("codespace", tx.Codespace),
 		zap.Error(err),
-		zap.String("tx_hash", txHash),
-		zap.Any("code", code),
 	)
 }
 
-func (p *Provider) logTxSuccess(height uint64, txHash string) {
+func (p *Provider) logTxSuccess(height uint64, txHash *sdkTypes.TxResponse) {
 	p.logger.Info("successful transaction",
 		zap.Uint64("block_height", height),
-		zap.String("tx_hash", txHash),
+		zap.String("tx_hash", txHash.TxHash),
 	)
 }
 
@@ -277,27 +276,27 @@ func (p *Provider) prepareAndPushTxToMemPool(ctx context.Context, acc, seq uint6
 	return res, nil
 }
 
-func (p *Provider) waitForTxResult(ctx context.Context, mk *relayTypes.MessageKey, txHash string, callback relayTypes.TxResponseFunc) {
-	for txWaitRes := range p.subscribeTxResultStream(ctx, txHash, p.cfg.TxConfirmationInterval) {
-		if txWaitRes.Error != nil && txWaitRes.Error != context.DeadlineExceeded {
-			p.logTxFailed(txWaitRes.Error, txHash, txWaitRes.TxResult.Code)
-			callback(mk, txWaitRes.TxResult, txWaitRes.Error)
-			return
-		}
-		p.logTxSuccess(uint64(txWaitRes.TxResult.Height), txHash)
-		callback(mk, txWaitRes.TxResult, nil)
+func (p *Provider) waitForTxResult(ctx context.Context, mk *relayTypes.MessageKey, tx *sdkTypes.TxResponse, callback relayTypes.TxResponseFunc) error {
+	res, err := p.subscribeTxResult(ctx, tx, p.cfg.TxConfirmationInterval)
+	if err != nil {
+		p.logTxFailed(err, tx)
+		callback(mk, res.TxResult, err)
+		return err
 	}
+	p.logTxSuccess(uint64(res.TxResult.Height), tx)
+	callback(mk, res.TxResult, nil)
+	return nil
 }
 
-func (p *Provider) pollTxResultStream(ctx context.Context, txHash string, maxWaitInterval time.Duration) <-chan *types.TxResultChan {
-	txResChan := make(chan *types.TxResultChan)
+func (p *Provider) pollTxResultStream(ctx context.Context, txHash string, maxWaitInterval time.Duration) <-chan *types.TxResult {
+	txResChan := make(chan *types.TxResult)
 	startTime := time.Now()
-	go func(txChan chan *types.TxResultChan) {
+	go func(txChan chan *types.TxResult) {
 		defer close(txChan)
 		for range time.NewTicker(p.cfg.TxConfirmationInterval).C {
 			res, err := p.client.GetTransactionReceipt(ctx, txHash)
 			if err == nil {
-				txChan <- &types.TxResultChan{
+				txChan <- &types.TxResult{
 					TxResult: &relayTypes.TxResponse{
 						Height:    res.TxResponse.Height,
 						TxHash:    res.TxResponse.TxHash,
@@ -308,7 +307,7 @@ func (p *Provider) pollTxResultStream(ctx context.Context, txHash string, maxWai
 				}
 				return
 			} else if time.Since(startTime) > maxWaitInterval {
-				txChan <- &types.TxResultChan{
+				txChan <- &types.TxResult{
 					Error: err,
 				}
 				return
@@ -318,79 +317,52 @@ func (p *Provider) pollTxResultStream(ctx context.Context, txHash string, maxWai
 	return txResChan
 }
 
-func (p *Provider) subscribeTxResultStream(ctx context.Context, txHash string, maxWaitInterval time.Duration) <-chan *types.TxResultChan {
-	txResChan := make(chan *types.TxResultChan)
-	go func(txRes chan *types.TxResultChan) {
-		defer close(txRes)
+func (p *Provider) subscribeTxResult(ctx context.Context, tx *sdkTypes.TxResponse, maxWaitInterval time.Duration) (*types.TxResult, error) {
+	newCtx, cancel := context.WithTimeout(ctx, maxWaitInterval)
+	defer cancel()
 
-		newCtx, cancel := context.WithTimeout(ctx, maxWaitInterval)
-		defer cancel()
+	query := fmt.Sprintf("tm.event = 'Tx' AND tx.hash = '%s'", tx.TxHash)
+	resultEventChan, err := p.client.Subscribe(newCtx, "tx-result-waiter", query)
+	if err != nil {
+		return &types.TxResult{
+			Error: err,
+			TxResult: &relayTypes.TxResponse{
+				TxHash: tx.TxHash,
+			},
+		}, err
+	}
+	defer p.client.Unsubscribe(newCtx, "tx-result-waiter", query)
 
-		query := fmt.Sprintf("tm.event = 'Tx' AND tx.hash = '%s'", txHash)
-		resultEventChan, err := p.client.Subscribe(newCtx, "tx-result-waiter", query)
-		if err != nil {
-			txRes <- &types.TxResultChan{
+	for {
+		select {
+		case <-ctx.Done():
+			return &types.TxResult{TxResult: nil}, ctx.Err()
+		case e := <-resultEventChan:
+			eventDataJSON, err := jsoniter.Marshal(e.Data)
+			if err != nil {
+				return &types.TxResult{TxResult: nil}, err
+			}
+
+			txRes := new(types.TxResultWaitResponse)
+			if err := jsoniter.Unmarshal(eventDataJSON, txRes); err != nil {
+				return &types.TxResult{TxResult: nil}, err
+			}
+
+			res := &types.TxResult{
 				TxResult: &relayTypes.TxResponse{
-					TxHash: txHash,
+					Height:    txRes.Height,
+					TxHash:    tx.TxHash,
+					Codespace: txRes.Result.Codespace,
+					Code:      relayTypes.ResponseCode(txRes.Result.Code),
+					Data:      string(txRes.Result.Data),
 				},
-				Error: err,
 			}
-			return
-		}
-		defer p.client.Unsubscribe(newCtx, "tx-result-waiter", query)
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case e := <-resultEventChan:
-				eventDataJSON, err := jsoniter.Marshal(e.Data)
-				if err != nil {
-					txRes <- &types.TxResultChan{
-						TxResult: &relayTypes.TxResponse{
-							TxHash: txHash,
-						}, Error: err,
-					}
-					return
-				}
-
-				txWaitRes := new(types.TxResultWaitResponse)
-				if err := jsoniter.Unmarshal(eventDataJSON, txWaitRes); err != nil {
-					txRes <- &types.TxResultChan{
-						TxResult: &relayTypes.TxResponse{
-							TxHash: txHash,
-						}, Error: err,
-					}
-					return
-				}
-				if uint32(txWaitRes.Result.Code) != types.CodeTypeOK {
-					txRes <- &types.TxResultChan{
-						Error: fmt.Errorf(txWaitRes.Result.Log),
-						TxResult: &relayTypes.TxResponse{
-							Height:    txWaitRes.Height,
-							TxHash:    txHash,
-							Codespace: txWaitRes.Result.Codespace,
-							Code:      relayTypes.ResponseCode(txWaitRes.Result.Code),
-							Data:      string(txWaitRes.Result.Data),
-						},
-					}
-					return
-				}
-
-				txRes <- &types.TxResultChan{
-					TxResult: &relayTypes.TxResponse{
-						Height:    txWaitRes.Height,
-						TxHash:    txHash,
-						Codespace: txWaitRes.Result.Codespace,
-						Code:      relayTypes.ResponseCode(txWaitRes.Result.Code),
-						Data:      string(txWaitRes.Result.Data),
-					},
-				}
-				return
+			if uint32(txRes.Result.Code) != types.CodeTypeOK {
+				res.Error = fmt.Errorf("transaction failed with code: %v", txRes.Result.Log)
 			}
+			return res, nil
 		}
-	}(txResChan)
-	return txResChan
+	}
 }
 
 func (p *Provider) MessageReceived(ctx context.Context, key *relayTypes.MessageKey) (bool, error) {

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -278,10 +278,7 @@ func (p *Provider) prepareAndPushTxToMemPool(ctx context.Context, acc, seq uint6
 
 func (p *Provider) waitForTxResult(ctx context.Context, mk *relayTypes.MessageKey, tx *sdkTypes.TxResponse, callback relayTypes.TxResponseFunc) error {
 	res, err := p.subscribeTxResult(ctx, tx, p.cfg.TxConfirmationInterval)
-	if err != nil || res.Error != nil {
-		if res.Error != nil {
-			err = res.Error
-		}
+	if err != nil {
 		callback(mk, res.TxResult, err)
 		p.logTxFailed(err, tx)
 		return err
@@ -356,13 +353,13 @@ func (p *Provider) subscribeTxResult(ctx context.Context, tx *sdkTypes.TxRespons
 					Height:    txRes.Height,
 					TxHash:    tx.TxHash,
 					Codespace: txRes.Result.Codespace,
-					Code:      relayTypes.ResponseCode(txRes.Result.Code),
 					Data:      string(txRes.Result.Data),
 				},
 			}
 			if uint32(txRes.Result.Code) != types.CodeTypeOK {
-				res.Error = fmt.Errorf("transaction failed with code: %v", txRes.Result.Log)
+				return res, fmt.Errorf("transaction failed with error: %v", txRes.Result.Log)
 			}
+			res.TxResult.Code = relayTypes.Success
 			return res, nil
 		}
 	}

--- a/relayer/chains/wasm/types/types.go
+++ b/relayer/chains/wasm/types/types.go
@@ -57,7 +57,7 @@ type TxResultWaitResponse struct {
 	} `json:"result"`
 }
 
-type TxResultChan struct {
+type TxResult struct {
 	TxResult *relayerTypes.TxResponse
 	Error    error
 }


### PR DESCRIPTION
This pull request fixes an issue where an error was not being returned for relay handle failed. The `WaitForTxResult` function now returns an error if the callback is nil. Additionally, the function now returns the error if the transaction status is not 1. This ensures that errors are properly handled and returned in the relay process.