### PR TITLE
fix: issue with closing recovered connection

### DIFF
--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -44,7 +44,6 @@ func newClient(ctx context.Context, connectionContract, XcallContract common.Add
 	}
 
 	reconnectFunc := func() (IClient, error) {
-		eth.Close()
 		newClient, err := newClient(ctx, connectionContract, XcallContract, rpcUrl, websocketUrl, l)
 		if err != nil {
 			return nil, err
@@ -235,5 +234,6 @@ func (c *Client) Subscribe(ctx context.Context, q ethereum.FilterQuery, ch chan<
 
 // Reconnect
 func (c *Client) Reconnect() (IClient, error) {
+	c.eth.Close()
 	return c.reconnect()
 }


### PR DESCRIPTION
This pull request fixes an issue where a recovered connection was being closed. The `newClient` function was modified to remove the line that closes the connection. Additionally, the `Reconnect` method was updated to close the connection before reconnecting. This ensures that the connection is properly handled and avoids any potential issues with closing a recovered connection.