### PR TITLE
fix: TCP connection errors and improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2024-07-01
+
+### Fixed
+
+- Avoid closing connection when errors are encountered
+- Cover all tcp connection errors
+- Other improvements and bug fixes
+
 ## [1.3.2] - 2024-07-01
 
 ### Fixed

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -44,11 +44,7 @@ func newClient(ctx context.Context, connectionContract, XcallContract common.Add
 	}
 
 	reconnectFunc := func() (IClient, error) {
-		newClient, err := newClient(ctx, connectionContract, XcallContract, rpcUrl, websocketUrl, l)
-		if err != nil {
-			return nil, err
-		}
-		return newClient, nil
+		return newClient(ctx, connectionContract, XcallContract, rpcUrl, websocketUrl, l)
 	}
 
 	return &Client{
@@ -234,6 +230,5 @@ func (c *Client) Subscribe(ctx context.Context, q ethereum.FilterQuery, ch chan<
 
 // Reconnect
 func (c *Client) Reconnect() (IClient, error) {
-	c.eth.Close()
 	return c.reconnect()
 }


### PR DESCRIPTION
This pull request includes fixes for TCP connection errors and improvements in error handling. The changes cover all TCP error scenarios and ensure that the connection is not closed when errors are encountered. Additionally, unnecessary code for closing the connection has been removed.


The client close seems cause issue, the client is interface to pointer and would close recovered connection.