### PR TITLE
Fix wasm keyring getting cleared randomly

### DIFF
--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -70,10 +70,10 @@ func (p *Provider) Init(ctx context.Context, homePath string, kms kms.KMS) error
 
 // Wallet returns the wallet of the provider
 func (p *Provider) Wallet() sdkTypes.AccAddress {
-	if p.wallet == nil {
-		ctx := context.Background()
-		done := p.SetSDKContext()
-		defer done()
+	ctx := context.Background()
+	done := p.SetSDKContext()
+	defer done()
+	if p.wallet == nil || p.wallet.GetAddress().Empty() {
 		if err := p.RestoreKeystore(ctx); err != nil {
 			p.logger.Error("failed to restore keystore", zap.Error(err))
 			return nil


### PR DESCRIPTION
This pull request fixes a bug where the wasm keyring is randomly cleared, resulting in an empty keystore and halting transactions. The bug appears to be unrelated to keystore restoration, as the error message states "address cannot be empty" while sending transactions. The restored wallet is somehow garbage collected.

The changes in this pull request ensure that the wallet is properly handled when it is garbage collected. The `Wallet()` function in the `Provider` struct now checks if the wallet is nil or if its address is empty before attempting to restore the keystore.

Fixes #288