### PR TITLE
Fix sequence increment on wallet initialization

### DIFF
--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -84,7 +84,7 @@ func (p *Provider) Wallet() sdkTypes.AccAddress {
 			return nil
 		}
 		p.wallet = account
-		p.wallet.SetSequence(account.GetSequence() + 1)
+		p.wallet.SetSequence(account.GetSequence())
 		return p.client.SetAddress(account.GetAddress())
 	}
 	return p.wallet.GetAddress()


### PR DESCRIPTION
The sequence increment on wallet initialization was incorrectly set to account.GetSequence() + 1. This pull request fixes the issue by setting the sequence increment to account.GetSequence().