### PR TITLE
rm: equality operator for wasm query and update fetchBlockMessages

### DIFF
--- a/relayer/chains/wasm/types/const.go
+++ b/relayer/chains/wasm/types/const.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	CodeTypeOK  uint32 = 0
-	CodeTypeErr uint32 = 1
-	ChainType          = "cosmos"
+	CodeTypeOK     uint32 = 0
+	CodeTypeErr    uint32 = 1
+	ChainType             = "cosmos"
+	ResultsPerPage        = 25
 )
 
 var (

--- a/relayer/chains/wasm/types/types.go
+++ b/relayer/chains/wasm/types/types.go
@@ -21,11 +21,11 @@ type TxSearchParam struct {
 func (param *TxSearchParam) BuildQuery() string {
 	startHeight := &Query{
 		Field: "tx.height", Value: param.StartHeight,
-		Operator: QueryOperator.Gte,
+		Operator: QueryOperator.Gt,
 	}
 	endHeight := &Query{
 		Field: "tx.height", Value: param.EndHeight,
-		Operator: QueryOperator.Lte,
+		Operator: QueryOperator.Lt,
 	}
 
 	var attribQueries []QueryExpression


### PR DESCRIPTION
This pull request removes the equality operator for the wasm query in the `provider.go` file to support all tendermint clients. It also updates the `fetchBlockMessages` function in the same file to use the `ResultsPerPage` constant instead of a hard-coded value.