### PR TITLE
rf: use rpc for maximum reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2024-07-17
+
+### Added
+
+- Support for the rollbackMessage event
+- Cosmwasmvm `v2.1.0` support
+
+### Changed
+
+- Use rpc instead of the websocket filterLogs `eth_getLogs` for the evm chain
+
 ## [1.3.4] - 2024-07-01
 
 ### Fixed

--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -22,23 +22,27 @@ const (
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {
-	eth, err := ethclient.DialContext(ctx, websocketUrl)
+	rpc, err := ethclient.DialContext(ctx, rpcUrl)
+	if err != nil {
+		return nil, err
+	}
+	ws, err := ethclient.DialContext(ctx, websocketUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	connection, err := bridgeContract.NewConnection(connectionContract, eth)
+	connection, err := bridgeContract.NewConnection(connectionContract, ws)
 	if err != nil {
 		return nil, fmt.Errorf("error occured when creating connection cobtract: %v ", err)
 	}
 
-	xcall, err := bridgeContract.NewXcall(XcallContract, eth)
+	xcall, err := bridgeContract.NewXcall(XcallContract, ws)
 	if err != nil {
 		return nil, fmt.Errorf("error occured when creating eth client: %v ", err)
 	}
 
 	// getting the chain id
-	evmChainId, err := eth.ChainID(ctx)
+	evmChainId, err := ws.ChainID(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +53,8 @@ func newClient(ctx context.Context, connectionContract, XcallContract common.Add
 
 	return &Client{
 		log:        l,
-		eth:        eth,
+		eth:        ws,
+		ethRpc:     rpc,
 		EVMChainID: evmChainId,
 		connection: connection,
 		xcall:      xcall,
@@ -129,7 +134,7 @@ func (cl *Client) GetBalance(ctx context.Context, hexAddr string) (*big.Int, err
 }
 
 func (cl *Client) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]ethTypes.Log, error) {
-	return cl.eth.FilterLogs(ctx, q)
+	return cl.ethRpc.FilterLogs(ctx, q)
 }
 
 func (cl *Client) GetBlockNumber(ctx context.Context) (uint64, error) {


### PR DESCRIPTION
This pull request changes the usage of the websocket filterLogs `eth_getLogs` for the evm chain to use rpc instead.