### PR TITLE
fix: used string as cache key and modified other required functions accordingly

### DIFF
--- a/relayer/chain_runtime_test.go
+++ b/relayer/chain_runtime_test.go
@@ -2,6 +2,7 @@ package relayer
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -43,8 +44,10 @@ func TestChainRuntime(t *testing.T) {
 	})
 
 	t.Run("clear messages", func(t *testing.T) {
+		fmt.Println(runtime.MessageCache)
 		runtime.clearMessageFromCache([]*types.MessageKey{m1.MessageKey()})
 		assert.Equal(t, len(runtime.MessageCache.Messages), len(info.Messages)-1)
-		assert.Equal(t, runtime.MessageCache.Messages[*m2.MessageKey()], types.NewRouteMessage(m2))
+		rtMsg, _ := runtime.MessageCache.Get(m2.MessageKey())
+		assert.Equal(t, rtMsg, types.NewRouteMessage(m2))
 	})
 }

--- a/relayer/chain_runtime_test.go
+++ b/relayer/chain_runtime_test.go
@@ -2,7 +2,6 @@ package relayer
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -44,7 +43,6 @@ func TestChainRuntime(t *testing.T) {
 	})
 
 	t.Run("clear messages", func(t *testing.T) {
-		fmt.Println(runtime.MessageCache)
 		runtime.clearMessageFromCache([]*types.MessageKey{m1.MessageKey()})
 		assert.Equal(t, len(runtime.MessageCache.Messages), len(info.Messages)-1)
 		rtMsg, _ := runtime.MessageCache.Get(m2.MessageKey())

--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -224,7 +224,6 @@ func (p *Provider) SetFee(ctx context.Context, networkID string, msgFee, resFee 
 	}
 	txr, err := p.client.WaitForResults(ctx, &types.TransactionHashParam{Hash: types.NewHexBytes(txHash)})
 	if err != nil {
-		fmt.Println("SetFee: WaitForResults: %v", err)
 		return fmt.Errorf("SetFee: WaitForResults: %v", err)
 	}
 	if txr.Status != types.NewHexInt(1) {

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -29,7 +29,6 @@ var (
 // main start loop
 func (r *Relayer) Start(ctx context.Context, flushInterval time.Duration, fresh bool) (chan error, error) {
 	errorChan := make(chan error, 1)
-
 	// once flush completes then only start processing
 	if fresh {
 		// flush all the packet and then continue
@@ -213,11 +212,11 @@ func (r *Relayer) getActiveMessagesFromStore(nId string, maxMessages uint) ([]*t
 
 func (r *Relayer) processMessages(ctx context.Context) {
 	for _, src := range r.chains {
-		for key, message := range src.MessageCache.Messages {
+		for _, message := range src.MessageCache.Messages {
 			dst, err := r.FindChainRuntime(message.Dst)
 			if err != nil {
 				r.log.Error("dst chain nid not found", zap.String("nid", message.Dst))
-				r.ClearMessages(ctx, []*types.MessageKey{&key}, src)
+				r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
 				continue
 			}
 
@@ -229,7 +228,8 @@ func (r *Relayer) processMessages(ctx context.Context) {
 			message.ToggleProcessing()
 
 			// if message reached delete the message
-			messageReceived, err := dst.Provider.MessageReceived(ctx, &key)
+
+			messageReceived, err := dst.Provider.MessageReceived(ctx, message.MessageKey())
 			if err != nil {
 				dst.log.Error("error occured when checking message received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()), zap.Error(err))
 				message.ToggleProcessing()
@@ -239,7 +239,7 @@ func (r *Relayer) processMessages(ctx context.Context) {
 			// if message is received we can remove the message from db
 			if messageReceived {
 				dst.log.Info("message already received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()))
-				r.ClearMessages(ctx, []*types.MessageKey{&key}, src)
+				r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
 				continue
 			}
 			go r.RouteMessage(ctx, message, dst, src)

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -195,7 +195,7 @@ func (m *MessageCache) Get(key *MessageKey) (*RouteMessage, bool) {
 }
 
 func (m *MessageCache) GetCacheKey(key *MessageKey) string {
-	return key.Src + "-" + key.Dst + "-" + key.Sn.String()
+	return key.Src + "-" + key.EventType + "-" + key.Sn.String()
 }
 
 func (m *MessageCache) HasCacheKey(cacheKey string) bool {

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -195,7 +195,7 @@ func (m *MessageCache) Get(key *MessageKey) (*RouteMessage, bool) {
 }
 
 func (m *MessageCache) GetCacheKey(key *MessageKey) string {
-	return key.Src + "-" + key.EventType + "-" + key.Sn.String()
+	return key.Src + "-" + key.Dst + "-" + key.EventType + "-" + key.Sn.String()
 }
 
 func (m *MessageCache) HasCacheKey(cacheKey string) bool {


### PR DESCRIPTION
The message cache was using object as key which was causing it to add duplicate packets when error occurred and packet was flushed from db to memory. 
The cache will now use string key(src,eventType and Sn) and added necessary checks to avoid adding duplicate packets to msg cache.
Also, updated test cases and issue causing the tcs to fail.