### PR TITLE
fix: wasm empty logs key for events

### DIFF
--- a/relayer/chains/wasm/events.go
+++ b/relayer/chains/wasm/events.go
@@ -6,6 +6,7 @@ import (
 
 	abiTypes "github.com/cometbft/cometbft/abci/types"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/icon-project/centralized-relay/relayer/chains/wasm/types"
 	"github.com/icon-project/centralized-relay/relayer/events"
 	relayerTypes "github.com/icon-project/centralized-relay/relayer/types"
 	"github.com/icon-project/centralized-relay/utils/hexstr"
@@ -32,21 +33,7 @@ const (
 	EventAttrKeyContractAddress string = "_contract_address"
 )
 
-type Event struct {
-	Type       string      `json:"type"`
-	Attributes []Attribute `json:"attributes"`
-}
-
-type Attribute struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type EventsList struct {
-	Events []Event `json:"events"`
-}
-
-func (p *Provider) ParseMessageFromEvents(eventsList []Event) ([]*relayerTypes.Message, error) {
+func (p *Provider) ParseMessageFromEvents(eventsList []types.Event) ([]*relayerTypes.Message, error) {
 	var messages []*relayerTypes.Message
 	for _, ev := range eventsList {
 		switch ev.Type {

--- a/relayer/chains/wasm/keys.go
+++ b/relayer/chains/wasm/keys.go
@@ -25,8 +25,6 @@ func (p *Provider) RestoreKeystore(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	done := p.SetSDKContext()
-	defer done()
 	if err := p.client.ImportArmor(p.NID(), priv, string(pass)); err != nil {
 		if strings.Contains(err.Error(), "cannot overwrite key") {
 			return nil

--- a/relayer/chains/wasm/types/types.go
+++ b/relayer/chains/wasm/types/types.go
@@ -54,13 +54,28 @@ func (param *TxSearchParam) BuildQuery() string {
 	return finalQuery.GetQuery()
 }
 
-type TxResultWaitResponse struct {
+type Event struct {
+	Type       string      `json:"type"`
+	Attributes []Attribute `json:"attributes"`
+}
+
+type Attribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type EventsList struct {
+	Events []Event `json:"events"`
+}
+
+type TxResultResponse struct {
 	Height int64 `json:"height"`
 	Result struct {
-		Code      int    `json:"code"`
-		Codespace string `json:"codespace"`
-		Data      []byte `json:"data"`
-		Log       string `json:"log"`
+		Code      int     `json:"code"`
+		Codespace string  `json:"codespace"`
+		Data      []byte  `json:"data"`
+		Log       string  `json:"log"`
+		Events    []Event `json:"events"`
 	} `json:"result"`
 }
 


### PR DESCRIPTION
Wasm looks like removed the logs key and is empty.

Now to fix this, events key is added on event data, this removes block of code that parses events manually. 