### PR TITLE
fix: removed default executing conditions with proper condition

### DIFF
--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -116,7 +116,7 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 
 	resetFunc := func() {
 		subscribeStarter.Reset(time.Second * 3)
-		pollHeightTicker.Reset(time.Second * 3)
+		pollHeightTicker.Reset(time.Second * 2)
 	}
 
 	p.logger.Info("Start from height", zap.Uint64("height", startHeight), zap.Uint64("finality block", p.FinalityBlock(ctx)))
@@ -146,9 +146,8 @@ func (p *Provider) Listener(ctx context.Context, lastSavedHeight uint64, blockIn
 			latestHeight, err = p.QueryLatestHeight(ctx)
 			if err != nil {
 				p.logger.Error("failed to get latest block height", zap.Error(err))
-				pollHeightTicker.Reset(time.Second * 3)
-			}
-		}
+				pollHeightTicker.Reset(time.Second * 2)
+			}		
 	}
 }
 


### PR DESCRIPTION
The checks in default block meant they were evaluated every time and causing high CPU usage.
- The client check has been changed to check after every 2 minutes similar to evm chains.
- The fetching block query has been changed to work in sync with subscription clients which will run if new subscription is started. This is similar to earlier as startheight only updates after client subscription changes which triggers pollHeightticker which updates start height.pollheightticker has been reduced by 1 sec to make sure it runs before the subscription.