### PR TITLE
fix: changed wasm event types

### DIFF
--- a/relayer/chains/wasm/events.go
+++ b/relayer/chains/wasm/events.go
@@ -6,7 +6,6 @@ import (
 
 	abiTypes "github.com/cometbft/cometbft/abci/types"
 	sdkTypes "github.com/cosmos/cosmos-sdk/types"
-	"github.com/icon-project/centralized-relay/relayer/chains/wasm/types"
 	"github.com/icon-project/centralized-relay/relayer/events"
 	relayerTypes "github.com/icon-project/centralized-relay/relayer/types"
 	"github.com/icon-project/centralized-relay/utils/hexstr"
@@ -33,7 +32,7 @@ const (
 	EventAttrKeyContractAddress string = "_contract_address"
 )
 
-func (p *Provider) ParseMessageFromEvents(eventsList []types.Event) ([]*relayerTypes.Message, error) {
+func (p *Provider) ParseMessageFromEvents(eventsList []abiTypes.Event) ([]*relayerTypes.Message, error) {
 	var messages []*relayerTypes.Message
 	for _, ev := range eventsList {
 		switch ev.Type {

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -611,30 +611,23 @@ func (p *Provider) fetchBlockMessages(ctx context.Context, heightInfo *types.Hei
 func (p *Provider) getMessagesFromTxList(resultTxList []*coreTypes.ResultTx) ([]*relayTypes.BlockInfo, error) {
 	var messages []*relayTypes.BlockInfo
 	for _, resultTx := range resultTxList {
-		var eventsList []*types.EventsList
-		if err := jsoniter.Unmarshal([]byte(resultTx.TxResult.Log), &eventsList); err != nil {
+		msgs, err := p.ParseMessageFromEvents(resultTx.TxResult.GetEvents())
+		if err != nil {
 			return nil, err
 		}
-
-		for _, event := range eventsList {
-			msgs, err := p.ParseMessageFromEvents(event.Events)
-			if err != nil {
-				return nil, err
-			}
-			for _, msg := range msgs {
-				msg.MessageHeight = uint64(resultTx.Height)
-				p.logger.Info("Detected eventlog",
-					zap.Uint64("height", msg.MessageHeight),
-					zap.String("target_network", msg.Dst),
-					zap.Uint64("sn", msg.Sn.Uint64()),
-					zap.String("event_type", msg.EventType),
-				)
-			}
-			messages = append(messages, &relayTypes.BlockInfo{
-				Height:   uint64(resultTx.Height),
-				Messages: msgs,
-			})
+		for _, msg := range msgs {
+			msg.MessageHeight = uint64(resultTx.Height)
+			p.logger.Info("Detected eventlog",
+				zap.Uint64("height", msg.MessageHeight),
+				zap.String("target_network", msg.Dst),
+				zap.Uint64("sn", msg.Sn.Uint64()),
+				zap.String("event_type", msg.EventType),
+			)
 		}
+		messages = append(messages, &relayTypes.BlockInfo{
+			Height:   uint64(resultTx.Height),
+			Messages: msgs,
+		})
 	}
 	return messages, nil
 }
@@ -733,7 +726,6 @@ func (p *Provider) SubscribeMessageEvents(ctx context.Context, blockInfoChan cha
 				p.logger.Error("failed to unmarshal event data", zap.Error(err))
 				continue
 			}
-
 			var messages []*relayTypes.Message
 			msgs, err := p.ParseMessageFromEvents(res.Result.Events)
 			if err != nil {

--- a/relayer/chains/wasm/types/types.go
+++ b/relayer/chains/wasm/types/types.go
@@ -56,20 +56,6 @@ func (param *TxSearchParam) BuildQuery() string {
 	return finalQuery.GetQuery()
 }
 
-type Event struct {
-	Type       string      `json:"type"`
-	Attributes []Attribute `json:"attributes"`
-}
-
-type Attribute struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-type EventsList struct {
-	Events []Event `json:"events"`
-}
-
 type TxResultResponse struct {
 	Height int64 `json:"height"`
 	Result struct {

--- a/relayer/chains/wasm/types/types.go
+++ b/relayer/chains/wasm/types/types.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
+	abiTypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/types"
+
 	relayerTypes "github.com/icon-project/centralized-relay/relayer/types"
 )
 
@@ -71,11 +73,11 @@ type EventsList struct {
 type TxResultResponse struct {
 	Height int64 `json:"height"`
 	Result struct {
-		Code      int     `json:"code"`
-		Codespace string  `json:"codespace"`
-		Data      []byte  `json:"data"`
-		Log       string  `json:"log"`
-		Events    []Event `json:"events"`
+		Code      int              `json:"code"`
+		Codespace string           `json:"codespace"`
+		Data      []byte           `json:"data"`
+		Log       string           `json:"log"`
+		Events    []abiTypes.Event `json:"events"`
 	} `json:"result"`
 }
 


### PR DESCRIPTION
This pr fixes an issue where events are not being parsed correctly due to changed event response format.

It now uses standard wasm abci types.
