### PR TITLE
refactor: ws healthcheck and add changelog for v1.5.0-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0-rc1] - 2024-08-03
+
+### Added
+
+- WASM conditional batch polling.
+
+### Changed
+
+- RPC retries and exponential backoffs.
+- Websocket healthcheck from 1 min to 10 second.
+- Initiate startup tasks early.
+
+### Fixed
+
+- Addressed wasm response format changes.
+- WASM chain healthcheck frquency.
+- WASM sdk context lockup issue.
+- WASM duplicated block when batching requests.
+- Recovery start from genesis block when databse is empty.
+- Docker build issues.
+
+### Removed
+
+- EVM and wasm unlimited concurrency.
+
 ## [1.4.1] - 2024-07-17
 
 ### Added

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -260,7 +260,7 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 		case <-time.After(time.Minute * 2):
 			ctx, cancel := context.WithTimeout(ctx, websocketReadTimeout)
 			defer cancel()
-			if _, err := p.client.GetHeaderByHeight(ctx, big.NewInt(1)); err != nil {
+			if _, err := p.QueryLatestHeight(ctx); err != nil {
 				resetCh <- err
 				return err
 			}


### PR DESCRIPTION
Refactored the ws healthcheck to use the latest height.

This is beacuse genesis blocks seems cached and never fails. 