### PR TITLE
add: logs for subsription ctx done

### DIFF
--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -235,9 +235,10 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			p.log.Debug("subscriptions stopped")
+			return ctx.Err()
 		case err := <-sub.Err():
-			p.log.Error("subscription error", zap.Error(err))
+			p.log.Warn("subscription error", zap.Error(err))
 			resetCh <- err
 			return err
 		case log := <-ch:


### PR DESCRIPTION
This pull request adds logs for when the subscription context is done in the `listener.go` file. Additionally, it updates the error log level from `Error` to `Warn` for subscription errors.