### PR TITLE
fix: added contextual timeout to requests creating clients in case of evm chains

### DIFF
--- a/relayer/chains/evm/client.go
+++ b/relayer/chains/evm/client.go
@@ -19,7 +19,7 @@ import (
 const (
 	DefaultPollingInterval = time.Second * 30
 	MaximumPollTry         = 15
-	DefaultCreateTimeout   = time.Second * 20
+	DefaultCreateTimeout   = time.Second * 10
 )
 
 func newClient(ctx context.Context, connectionContract, XcallContract common.Address, rpcUrl, websocketUrl string, l *zap.Logger) (IClient, error) {

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -27,6 +27,7 @@ const (
 	BaseRetryInterval          = 3 * time.Second
 	MaxRetryInterval           = 5 * time.Minute
 	MaxRetryCount              = 5
+	ClientReconnectDelay       = 5 * time.Second
 )
 
 type BnOptions struct {
@@ -55,7 +56,6 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 	if err != nil {
 		return err
 	}
-
 	p.log.Info("Start from height ", zap.Uint64("height", startHeight), zap.Uint64("finality block", p.FinalityBlock(ctx)))
 
 	var (
@@ -71,13 +71,21 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 		case err := <-errChan:
 			if p.isConnectionError(err) {
 				p.log.Error("connection error", zap.Error(err))
-				client, err := p.client.Reconnect()
-				if err != nil {
-					p.log.Error("failed to reconnect", zap.Error(err))
-				} else {
-					p.log.Info("client reconnected")
-					p.client = client
+				clientReconnected := false
+				var client IClient
+				var err error
+				for !clientReconnected {
+					p.log.Info("Reconnecting client")
+					client, err = p.client.Reconnect()
+					if err == nil {
+						clientReconnected = true
+					} else {
+						p.log.Error("failed to re-connect", zap.Error(err))
+						time.Sleep(ClientReconnectDelay)
+					}
 				}
+				p.log.Info("client reconnected")
+				p.client = client
 			}
 			startHeight = p.GetLastSavedBlockHeight()
 			subscribeStart.Reset(time.Second * 1)

--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -71,21 +71,17 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 		case err := <-errChan:
 			if p.isConnectionError(err) {
 				p.log.Error("connection error", zap.Error(err))
-				clientReconnected := false
-				var client IClient
-				var err error
-				for !clientReconnected {
-					p.log.Info("Reconnecting client")
-					client, err = p.client.Reconnect()
+				for err != nil {
+					p.log.Info("reconnecting client")
+					client, err := p.client.Reconnect()
 					if err == nil {
-						clientReconnected = true
+						p.log.Info("client reconnected")
+						p.client = client
 					} else {
 						p.log.Error("failed to re-connect", zap.Error(err))
 						time.Sleep(ClientReconnectDelay)
 					}
 				}
-				p.log.Info("client reconnected")
-				p.client = client
 			}
 			startHeight = p.GetLastSavedBlockHeight()
 			subscribeStart.Reset(time.Second * 1)


### PR DESCRIPTION
currently we have no timeout while creating evm clients so in some problematic rpc providers, the process gets stuck,connection error occurs and sometimes neither success nor failure is logged for hours.

added timeout to request while creating clients and retry until a new client is connected in case of reconnection.