### PR TITLE
feat: common keystore utility

### DIFF
--- a/cmd/keystore.go
+++ b/cmd/keystore.go
@@ -170,8 +170,9 @@ func (k *keystoreState) importKey(a *appState) *cobra.Command {
 // converts private key to keystore
 func (k *keystoreState) convertKey(a *appState) *cobra.Command {
 	convertCmd := &cobra.Command{
-		Use:   "convert",
-		Short: "convert keystore",
+		Use:     "convert",
+		Short:   "convert keystore",
+		Example: "centralized-relay keystore convert --keystore ~/.sui/sui_config/sui.keystore --chain sui --password password",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chain, err := a.config.Chains.Get(k.chain)
 			if err != nil {

--- a/cmd/keystore.go
+++ b/cmd/keystore.go
@@ -187,12 +187,12 @@ func (k *keystoreState) convertKey(a *appState) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stdout, "Private key converted to keystore at: %s\n", convertedKeystorePath)
+			fmt.Fprintf(os.Stdout, "private key converted to keystore at: %s\n", convertedKeystorePath)
 			return nil
 		},
 	}
 	k.chainFlag(convertCmd)
-	k.passwordFlag(convertCmd, true)
+	k.passwordFlag(convertCmd, false)
 	k.keystorePathFlag(convertCmd)
 	return convertCmd
 }

--- a/relayer/chains/evm/keys.go
+++ b/relayer/chains/evm/keys.go
@@ -96,5 +96,5 @@ func (p *Provider) keystorePath(addr string) string {
 }
 
 func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
-	return "", fmt.Errorf("not required for evm chains")
+	return "", fmt.Errorf("not applicable for evm chains")
 }

--- a/relayer/chains/evm/keys.go
+++ b/relayer/chains/evm/keys.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 
@@ -92,4 +93,8 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 // keystorePath is the path to the keystore file
 func (p *Provider) keystorePath(addr string) string {
 	return path.Join(p.cfg.HomeDir, "keystore", p.NID(), addr)
+}
+
+func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
+	return "", fmt.Errorf("not required for evm chains")
 }

--- a/relayer/chains/icon/keys.go
+++ b/relayer/chains/icon/keys.go
@@ -99,5 +99,5 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 }
 
 func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
-	return "", fmt.Errorf("not required for icon chain")
+	return "", fmt.Errorf("not applicable for icon chain")
 }

--- a/relayer/chains/icon/keys.go
+++ b/relayer/chains/icon/keys.go
@@ -2,6 +2,7 @@ package icon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 
@@ -95,4 +96,8 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 		return "", err
 	}
 	return addr, nil
+}
+
+func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
+	return "", fmt.Errorf("not required for icon chain")
 }

--- a/relayer/chains/mockchain/provider.go
+++ b/relayer/chains/mockchain/provider.go
@@ -189,7 +189,7 @@ func (p *MockProvider) ImportKeystore(context.Context, string, string) (string, 
 }
 
 func (p *MockProvider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
-	return "", fmt.Errorf("not required for mock chain")
+	return "", fmt.Errorf("not applicable for mock chain")
 }
 
 func (p *MockProvider) Init(context.Context, string, kms.KMS) error {

--- a/relayer/chains/mockchain/provider.go
+++ b/relayer/chains/mockchain/provider.go
@@ -2,6 +2,7 @@ package mockchain
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -185,6 +186,10 @@ func (p *MockProvider) RestoreKeystore(context.Context) error {
 }
 func (p *MockProvider) ImportKeystore(context.Context, string, string) (string, error) {
 	return "", nil
+}
+
+func (p *MockProvider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
+	return "", fmt.Errorf("not required for mock chain")
 }
 
 func (p *MockProvider) Init(context.Context, string, kms.KMS) error {

--- a/relayer/chains/sui/keys.go
+++ b/relayer/chains/sui/keys.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cometbft/cometbft/libs/rand"
 	"github.com/coming-chat/go-sui/v2/account"
 	"github.com/coming-chat/go-sui/v2/sui_types"
+	utilKeystore "github.com/icon-project/centralized-relay/utils/keystore"
 )
 
 type KeyPair byte
@@ -30,17 +31,32 @@ func fetchKeyPair(privateKey string) (*account.Account, error) {
 // Restores the addres configured
 func (p *Provider) RestoreKeystore(ctx context.Context) error {
 	path := p.keystorePath(p.cfg.Address)
-	keystore, err := os.ReadFile(path)
+	kmsEncryptedKeystore, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("error restoring account: %w", err)
+		return err
 	}
-	privateKey, err := p.kms.Decrypt(ctx, keystore)
+	keystoreData, err := p.kms.Decrypt(ctx, kmsEncryptedKeystore)
 	if err != nil {
-		return fmt.Errorf("error restoring account: %w", err)
+		return err
 	}
+
+	passFile, err := os.ReadFile(path + ".pass")
+	if err != nil {
+		return err
+	}
+	pass, err := p.kms.Decrypt(ctx, passFile)
+	if err != nil {
+		return err
+	}
+
+	privateKey, _, err := utilKeystore.DecryptFromJSONKeystore(keystoreData, string(pass))
+	if err != nil {
+		return err
+	}
+
 	p.wallet, err = fetchKeyPair(string(privateKey))
 	if err != nil {
-		return fmt.Errorf("error restoring account: %w", err)
+		return err
 	}
 	return nil
 }
@@ -53,8 +69,13 @@ func (p *Provider) NewKeystore(password string) (string, error) {
 	}
 	account := account.NewAccount(signatureScheme, rand.Bytes(32))
 	privateKeyWithFlag := append([]byte{byte(Ed25519Flag)}, account.KeyPair.PrivateKey()[:ed25519PublicKeyLength]...)
-	encodedPkey := base64.StdEncoding.EncodeToString([]byte(privateKeyWithFlag))
-	keyStoreContent, err := p.kms.Encrypt(context.Background(), []byte(encodedPkey))
+
+	keystoreData, err := utilKeystore.EncryptToJSONKeystore(privateKeyWithFlag, account.Address, password)
+	if err != nil {
+		return "", err
+	}
+
+	keyStoreContent, err := p.kms.Encrypt(context.Background(), keystoreData)
 	if err != nil {
 		return "", fmt.Errorf("error adding new account: %w", err)
 	}
@@ -74,22 +95,17 @@ func (p *Provider) NewKeystore(password string) (string, error) {
 
 // Imports first ed25519 key pair from the keystore
 func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase string) (string, error) {
-	privFile, err := os.ReadFile(keyPath)
+	jsonKeystoreData, err := os.ReadFile(keyPath)
 	if err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
-	var ksData []string
-	err = json.Unmarshal(privFile, &ksData)
+
+	encrypedKeystoreBytes, addr, err := utilKeystore.DecryptFromJSONKeystore(jsonKeystoreData, passphrase)
 	if err != nil {
-		return "", fmt.Errorf("error importing key: %w", err)
+		return "", err
 	}
-	//decode base64 for first key
-	firstKeyPairString := string(ksData[0])
-	keyPair, err := fetchKeyPair(firstKeyPairString)
-	if err != nil {
-		return "", fmt.Errorf("error importing key: %w", err)
-	}
-	keyStoreContent, err := p.kms.Encrypt(ctx, []byte(firstKeyPairString))
+
+	keyStoreContent, err := p.kms.Encrypt(ctx, encrypedKeystoreBytes)
 	if err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
@@ -97,17 +113,53 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 	if err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
-	path := p.keystorePath(keyPair.Address)
+	path := p.keystorePath(addr)
 	if err = os.WriteFile(path, keyStoreContent, 0o644); err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
 	if err = os.WriteFile(path+".pass", passphraseCipher, 0o644); err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
-	return keyPair.Address, nil
+	return addr, nil
 }
 
 // keystorePath is the path to the keystore file
 func (p *Provider) keystorePath(addr string) string {
 	return path.Join(p.cfg.HomeDir, "keystore", p.NID(), addr)
+}
+
+// Convert private to keystore
+func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
+	privFile, err := os.ReadFile(keyPath)
+	if err != nil {
+		return "", err
+	}
+	var ksData []string
+	err = json.Unmarshal(privFile, &ksData)
+	if err != nil {
+		return "", err
+	}
+	//decode base64 for first key
+	firstKeyPairString := string(ksData[0])
+	keyPair, err := fetchKeyPair(firstKeyPairString)
+	if err != nil {
+		return "", err
+	}
+
+	pkey, err := base64.StdEncoding.DecodeString(firstKeyPairString)
+	if err != nil {
+		return "", err
+	}
+
+	jsonKeystoreBytes, err := utilKeystore.EncryptToJSONKeystore(pkey, keyPair.Address, passphrase)
+	if err != nil {
+		return "", err
+	}
+
+	path := p.keystorePath(keyPair.Address) + "_keystore.json"
+	if err = os.WriteFile(path, jsonKeystoreBytes, 0o644); err != nil {
+		return "", err
+	}
+
+	return path, nil
 }

--- a/relayer/chains/sui/keys.go
+++ b/relayer/chains/sui/keys.go
@@ -54,7 +54,8 @@ func (p *Provider) RestoreKeystore(ctx context.Context) error {
 		return err
 	}
 
-	p.wallet, err = fetchKeyPair(string(privateKey))
+	base64Pkey := base64.StdEncoding.EncodeToString(privateKey)
+	p.wallet, err = fetchKeyPair(base64Pkey)
 	if err != nil {
 		return err
 	}
@@ -100,12 +101,12 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 		return "", fmt.Errorf("error importing key: %w", err)
 	}
 
-	encrypedKeystoreBytes, addr, err := utilKeystore.DecryptFromJSONKeystore(jsonKeystoreData, passphrase)
+	_, addr, err := utilKeystore.DecryptFromJSONKeystore(jsonKeystoreData, passphrase)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error importing key: %w", err)
 	}
 
-	keyStoreContent, err := p.kms.Encrypt(ctx, encrypedKeystoreBytes)
+	keyStoreContent, err := p.kms.Encrypt(ctx, jsonKeystoreData)
 	if err != nil {
 		return "", fmt.Errorf("error importing key: %w", err)
 	}

--- a/relayer/chains/wasm/keys.go
+++ b/relayer/chains/wasm/keys.go
@@ -107,5 +107,5 @@ func (p *Provider) keystorePath(addr string) string {
 }
 
 func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
-	return "", fmt.Errorf("not required for wasm chains")
+	return "", fmt.Errorf("not applicable for wasm chains")
 }

--- a/relayer/chains/wasm/keys.go
+++ b/relayer/chains/wasm/keys.go
@@ -2,6 +2,7 @@ package wasm
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -103,4 +104,8 @@ func (p *Provider) ImportKeystore(ctx context.Context, keyPath, passphrase strin
 // keystorePath is the path to the keystore file
 func (p *Provider) keystorePath(addr string) string {
 	return path.Join(p.cfg.HomeDir, "keystore", p.NID(), addr)
+}
+
+func (p *Provider) ConvertPrivateKey(ctx context.Context, keyPath, passphrase string) (string, error) {
+	return "", fmt.Errorf("not required for wasm chains")
 }

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -45,6 +45,7 @@ type ChainProvider interface {
 	NewKeystore(string) (string, error)
 	RestoreKeystore(context.Context) error
 	ImportKeystore(context.Context, string, string) (string, error)
+	ConvertPrivateKey(context.Context, string, string) (string, error)
 	RevertMessage(context.Context, *big.Int) error
 	GetFee(context.Context, string, bool) (uint64, error)
 	SetFee(context.Context, string, *big.Int, *big.Int) error

--- a/utils/keystore/keystore.go
+++ b/utils/keystore/keystore.go
@@ -1,0 +1,125 @@
+package keystore
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	kdf  = "scrypt"
+	algo = "aes-256-gcm"
+)
+
+type EncryptedKey struct {
+	Address    string `json:"address"`
+	Ciphertext string `json:"ciphertext"`
+	Salt       string `json:"salt"`
+	IV         string `json:"iv"`
+	KDF        string `json:"kdf"`
+	Algorithm  string `json:"algorithm"`
+}
+
+func EncryptToJSONKeystore(privateKey []byte, address string, password string) ([]byte, error) {
+	// Generate a random salt
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+
+	// Derive a key using scrypt
+	key, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	// Encrypt the private key using AES-GCM
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate a random IV
+	iv := make([]byte, aesGCM.NonceSize())
+	if _, err := rand.Read(iv); err != nil {
+		return nil, err
+	}
+
+	ciphertext := aesGCM.Seal(nil, iv, []byte(privateKey), nil)
+
+	// Prepare the JSON data
+	encryptedKey := EncryptedKey{
+		Address:    address,
+		Ciphertext: base64.URLEncoding.EncodeToString(ciphertext),
+		Salt:       base64.URLEncoding.EncodeToString(salt),
+		IV:         base64.URLEncoding.EncodeToString(iv),
+		KDF:        kdf,
+		Algorithm:  algo,
+	}
+
+	// Marshal to JSON
+	data, err := json.MarshalIndent(encryptedKey, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func DecryptFromJSONKeystore(encryptedJSONBytes []byte, password string) ([]byte, error) {
+	var encryptedKey EncryptedKey
+	if err := json.Unmarshal(encryptedJSONBytes, &encryptedKey); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	// Decode base64 values
+	salt, err := base64.URLEncoding.DecodeString(encryptedKey.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode salt: %w", err)
+	}
+
+	iv, err := base64.URLEncoding.DecodeString(encryptedKey.IV)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode IV: %w", err)
+	}
+
+	ciphertext, err := base64.URLEncoding.DecodeString(encryptedKey.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode ciphertext: %w", err)
+	}
+
+	// Derive the key using scrypt
+	key, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive key: %w", err)
+	}
+
+	// Create the AES-GCM cipher block
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	// Decrypt the ciphertext
+	privateKey, err := aesGCM.Open(nil, iv, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt private key: %w", err)
+	}
+
+	return privateKey, nil
+}

--- a/utils/keystore/keystore_test.go
+++ b/utils/keystore/keystore_test.go
@@ -1,0 +1,41 @@
+package keystore
+
+import (
+	"fmt"
+	"testing"
+
+	bftRand "github.com/cometbft/cometbft/libs/rand"
+
+	"github.com/coming-chat/go-sui/v2/account"
+	"github.com/coming-chat/go-sui/v2/sui_types"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	Ed25519Flag            byte = 0
+	ed25519PublicKeyLength      = 32
+)
+
+func TestJSONkeystore(t *testing.T) {
+	signatureScheme, err := sui_types.NewSignatureScheme(byte(Ed25519Flag))
+	assert.NoError(t, err)
+
+	account := account.NewAccount(signatureScheme, bftRand.Bytes(32))
+	privateKeyWithFlag := append([]byte{byte(Ed25519Flag)}, account.KeyPair.PrivateKey()[:ed25519PublicKeyLength]...)
+
+	password := "password"
+
+	jsonBytes, err := EncryptToJSONKeystore(privateKeyWithFlag, account.Address, password)
+	assert.NoError(t, err)
+
+	fmt.Println("JSON Keystore: ", string(jsonBytes))
+
+	decryptedPrivateKey, err := DecryptFromJSONKeystore(jsonBytes, password)
+	assert.NoError(t, err)
+
+	assert.Equal(t, privateKeyWithFlag, decryptedPrivateKey)
+
+	wrongPassword := "wrongPassword"
+	_, err = DecryptFromJSONKeystore(jsonBytes, wrongPassword)
+	assert.Contains(t, err.Error(), "cipher: message authentication failed")
+}

--- a/utils/keystore/keystore_test.go
+++ b/utils/keystore/keystore_test.go
@@ -30,12 +30,12 @@ func TestJSONkeystore(t *testing.T) {
 
 	fmt.Println("JSON Keystore: ", string(jsonBytes))
 
-	decryptedPrivateKey, err := DecryptFromJSONKeystore(jsonBytes, password)
+	decryptedPrivateKey, _, err := DecryptFromJSONKeystore(jsonBytes, password)
 	assert.NoError(t, err)
 
 	assert.Equal(t, privateKeyWithFlag, decryptedPrivateKey)
 
 	wrongPassword := "wrongPassword"
-	_, err = DecryptFromJSONKeystore(jsonBytes, wrongPassword)
+	_, _, err = DecryptFromJSONKeystore(jsonBytes, wrongPassword)
 	assert.Contains(t, err.Error(), "cipher: message authentication failed")
 }


### PR DESCRIPTION
This feature can be used to encrypt the private key of chains using `aes-256-gcm` algorithm with the passphrase so that the extra layer of security is added for the keystore. 

Some chains like ICON and EVM chains inherently have this feature in their CLI tools. But chains like SUI doesn't have it. For such chains this feature is useful.
 