### PR TITLE
fix: fixed client creation loop stuck issue

### DIFF
--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -71,10 +71,12 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 		case err := <-errChan:
 			if p.isConnectionError(err) {
 				p.log.Error("connection error", zap.Error(err))
-				for err != nil {
+				clientReconnected := false
+				for !clientReconnected {
 					p.log.Info("reconnecting client")
 					client, err := p.client.Reconnect()
 					if err == nil {
+						clientReconnected = true
 						p.log.Info("client reconnected")
 						p.client = client
 					} else {


### PR DESCRIPTION
the issue was caused due to variable mixing and using wrong scored variables for checking