### PR TITLE
fix: add proper logs for event log detection and message routing in icon

### DIFF
--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -123,11 +123,12 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 						continue
 					}
 					p.log.Info("Detected eventlog",
-						zap.String("target_network", message.Dst),
+						zap.String("dst", message.Dst),
 						zap.Uint64("sn", message.Sn.Uint64()),
+						zap.Any("req_id", message.ReqID),
 						zap.String("event_type", message.EventType),
 						zap.String("tx_hash", log.TxHash.String()),
-						zap.Uint64("block_number", log.BlockNumber),
+						zap.Uint64("height", log.BlockNumber),
 					)
 					blockInfoChan <- &relayertypes.BlockInfo{
 						Height:   log.BlockNumber,
@@ -177,10 +178,12 @@ func (p *Provider) FindMessages(ctx context.Context, lbn *types.BlockNotificatio
 			return nil, err
 		}
 		p.log.Info("Detected eventlog",
-			zap.Uint64("height", lbn.Height.Uint64()),
-			zap.String("target_network", message.Dst),
+			zap.String("dst", message.Dst),
 			zap.Uint64("sn", message.Sn.Uint64()),
+			zap.Any("req_id", message.ReqID),
 			zap.String("event_type", message.EventType),
+			zap.String("tx_hash", log.TxHash.String()),
+			zap.Uint64("height", log.BlockNumber),
 		)
 		messages = append(messages, message)
 	}
@@ -256,11 +259,12 @@ func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertyp
 				continue
 			}
 			p.log.Info("Detected eventlog",
-				zap.String("target_network", message.Dst),
+				zap.String("dst", message.Dst),
 				zap.Uint64("sn", message.Sn.Uint64()),
+				zap.Any("req_id", message.ReqID),
 				zap.String("event_type", message.EventType),
 				zap.String("tx_hash", log.TxHash.String()),
-				zap.Uint64("block_number", log.BlockNumber),
+				zap.Uint64("height", log.BlockNumber),
 			)
 			blockInfoChan <- &relayertypes.BlockInfo{
 				Height:   log.BlockNumber,

--- a/relayer/chains/evm/route.go
+++ b/relayer/chains/evm/route.go
@@ -26,7 +26,11 @@ func (p *Provider) Route(ctx context.Context, message *providerTypes.Message, ca
 	// lock here to prevent transcation replacement
 	p.routerMutex.Lock()
 
-	p.log.Info("starting to route message", zap.Any("message", message))
+	p.log.Info("starting to route message",
+		zap.Any("sn", message.Sn),
+		zap.Any("req_id", message.ReqID),
+		zap.String("src", message.Src),
+		zap.String("event_type", message.EventType))
 
 	opts, err := p.GetTransationOpts(ctx)
 	if err != nil {

--- a/relayer/chains/icon/event_parse.go
+++ b/relayer/chains/icon/event_parse.go
@@ -85,10 +85,12 @@ func (p *Provider) parseCallMessage(e *types.EventLog, eventType string, height 
 
 // Parse Event
 func (p *Provider) parseMessageEvent(notifications *types.EventNotification) ([]*providerTypes.Message, error) {
-	height, err := notifications.Height.BigInt()
+	aboveHeight, err := notifications.Height.BigInt()
 	if err != nil {
 		return nil, err
 	}
+	height := aboveHeight.Sub(aboveHeight, big.NewInt(1))
+
 	var messages []*providerTypes.Message
 	for _, event := range notifications.Logs {
 		switch event.Indexed[0] {

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -93,7 +93,6 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx providerTypes.L
 								zap.Uint64("req-id", msg.ReqID.Uint64()),
 								zap.String("src", msg.Src),
 								zap.String("dst", msg.Dst),
-								zap.String("tx_hash", v.Hash.String()),
 								zap.String("event_type", msg.EventType),
 								zap.Any("data", hex.EncodeToString(msg.Data)),
 							)

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -2,7 +2,6 @@ package icon
 
 import (
 	"context"
-	"encoding/hex"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -89,12 +88,11 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx providerTypes.L
 						}
 						for _, msg := range msgs {
 							p.log.Info("Detected eventlog",
-								zap.Uint64("sn", msg.Sn.Uint64()),
-								zap.Uint64("req_id", msg.ReqID.Uint64()),
-								zap.String("src", msg.Src),
 								zap.String("dst", msg.Dst),
+								zap.Uint64("sn", msg.Sn.Uint64()),
+								zap.Any("req_id", msg.ReqID),
 								zap.String("event_type", msg.EventType),
-								zap.Any("data", hex.EncodeToString(msg.Data)),
+								zap.Uint64("height", msg.MessageHeight),
 							)
 							outgoing <- &providerTypes.BlockInfo{
 								Messages: []*providerTypes.Message{msg},

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -2,6 +2,7 @@ package icon
 
 import (
 	"context"
+	"encoding/hex"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -88,11 +89,13 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx providerTypes.L
 						}
 						for _, msg := range msgs {
 							p.log.Info("Detected eventlog",
-								zap.Uint64("height", msg.MessageHeight),
-								zap.String("target_network", msg.Dst),
 								zap.Uint64("sn", msg.Sn.Uint64()),
+								zap.Uint64("req-id", msg.ReqID.Uint64()),
+								zap.String("src", msg.Src),
+								zap.String("dst", msg.Dst),
 								zap.String("tx_hash", v.Hash.String()),
 								zap.String("event_type", msg.EventType),
+								zap.Any("data", hex.EncodeToString(msg.Data)),
 							)
 							outgoing <- &providerTypes.BlockInfo{
 								Messages: []*providerTypes.Message{msg},

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -90,7 +90,7 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx providerTypes.L
 						for _, msg := range msgs {
 							p.log.Info("Detected eventlog",
 								zap.Uint64("sn", msg.Sn.Uint64()),
-								zap.Uint64("req-id", msg.ReqID.Uint64()),
+								zap.Uint64("req_id", msg.ReqID.Uint64()),
 								zap.String("src", msg.Src),
 								zap.String("dst", msg.Dst),
 								zap.String("event_type", msg.EventType),

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -15,9 +15,9 @@ import (
 func (p *Provider) Route(ctx context.Context, message *providerTypes.Message, callback providerTypes.TxResponseFunc) error {
 	p.log.Info("starting to route message",
 		zap.Any("sn", message.Sn),
-		zap.Any("req-id", message.ReqID),
+		zap.Any("req_id", message.ReqID),
 		zap.String("src", message.Src),
-		zap.String("event-type", message.EventType),
+		zap.String("event_type", message.EventType),
 		zap.String("data", hex.EncodeToString(message.Data)))
 
 	iconMessage, err := p.MakeIconMessage(message)

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -2,6 +2,7 @@ package icon
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/icon-project/centralized-relay/relayer/chains/icon/types"
@@ -12,7 +13,13 @@ import (
 )
 
 func (p *Provider) Route(ctx context.Context, message *providerTypes.Message, callback providerTypes.TxResponseFunc) error {
-	p.log.Info("starting to route message", zap.Any("message", message))
+	p.log.Info("starting to route message",
+		zap.Any("sn", message.Sn),
+		zap.Any("req-id", message.ReqID),
+		zap.String("src", message.Src),
+		zap.String("event-type", message.EventType),
+		zap.String("data", hex.EncodeToString(message.Data)))
+
 	iconMessage, err := p.MakeIconMessage(message)
 	if err != nil {
 		return err

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -2,7 +2,6 @@ package icon
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 
 	"github.com/icon-project/centralized-relay/relayer/chains/icon/types"
@@ -17,8 +16,7 @@ func (p *Provider) Route(ctx context.Context, message *providerTypes.Message, ca
 		zap.Any("sn", message.Sn),
 		zap.Any("req_id", message.ReqID),
 		zap.String("src", message.Src),
-		zap.String("event_type", message.EventType),
-		zap.String("data", hex.EncodeToString(message.Data)))
+		zap.String("event_type", message.EventType))
 
 	iconMessage, err := p.MakeIconMessage(message)
 	if err != nil {

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -2,7 +2,6 @@ package sui
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -79,8 +78,7 @@ func (p *Provider) parseMessagesFromEvents(events []types.EventResponse) ([]rela
 			zap.Any("sn", msg.Sn),
 			zap.String("dst", msg.Dst),
 			zap.Any("req_id", msg.ReqID),
-			zap.String("dapp-module-cap-id", msg.DappModuleCapID),
-			zap.Any("data", hex.EncodeToString(msg.Data)),
+			zap.String("tx_hash", ev.Id.TxDigest.String()),
 		)
 		checkpointMessages[ev.Checkpoint.Uint64()] = append(checkpointMessages[ev.Checkpoint.Uint64()], msg)
 	}
@@ -222,8 +220,7 @@ func (p *Provider) handleEventNotification(ctx context.Context, ev types.EventRe
 		zap.Any("sn", msg.Sn),
 		zap.String("dst", msg.Dst),
 		zap.Any("req_id", msg.ReqID),
-		zap.String("dapp_module_cap_id", msg.DappModuleCapID),
-		zap.Any("data", hex.EncodeToString(msg.Data)),
+		zap.String("tx_hash", ev.Id.TxDigest.String()),
 	)
 
 	blockStream <- &relayertypes.BlockInfo{

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -75,10 +75,10 @@ func (p *Provider) parseMessagesFromEvents(events []types.EventResponse) ([]rela
 
 		p.log.Info("Detected event log: ",
 			zap.Uint64("checkpoint", msg.MessageHeight),
-			zap.String("event-type", msg.EventType),
+			zap.String("event_type", msg.EventType),
 			zap.Any("sn", msg.Sn),
 			zap.String("dst", msg.Dst),
-			zap.Any("req-id", msg.ReqID),
+			zap.Any("req_id", msg.ReqID),
 			zap.String("dapp-module-cap-id", msg.DappModuleCapID),
 			zap.Any("data", hex.EncodeToString(msg.Data)),
 		)
@@ -218,11 +218,11 @@ func (p *Provider) handleEventNotification(ctx context.Context, ev types.EventRe
 
 	p.log.Info("Detected event log: ",
 		zap.Uint64("checkpoint", msg.MessageHeight),
-		zap.String("event-type", msg.EventType),
+		zap.String("event_type", msg.EventType),
 		zap.Any("sn", msg.Sn),
 		zap.String("dst", msg.Dst),
-		zap.Any("req-id", msg.ReqID),
-		zap.String("dapp-module-cap-id", msg.DappModuleCapID),
+		zap.Any("req_id", msg.ReqID),
+		zap.String("dapp_module_cap_id", msg.DappModuleCapID),
 		zap.Any("data", hex.EncodeToString(msg.Data)),
 	)
 

--- a/relayer/chains/sui/provider_test.go
+++ b/relayer/chains/sui/provider_test.go
@@ -182,7 +182,7 @@ func TestQueryTxBlocks(t *testing.T) {
 				zap.String("checkpoint", checkpoint),
 				zap.String("package-id", ev.PackageId.String()),
 				zap.String("module", ev.TransactionModule),
-				zap.String("event-type", ev.Type),
+				zap.String("event_type", ev.Type),
 				zap.String("tx-digest", ev.Id.TxDigest.String()),
 			)
 		}

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -27,8 +27,7 @@ func (p *Provider) Route(ctx context.Context, message *relayertypes.Message, cal
 		zap.Any("sn", message.Sn),
 		zap.Any("req_id", message.ReqID),
 		zap.String("src", message.Src),
-		zap.String("event_type", message.EventType),
-		zap.String("data", hex.EncodeToString(message.Data)))
+		zap.String("event_type", message.EventType))
 
 	suiMessage, err := p.MakeSuiMessage(message)
 	if err != nil {

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -24,9 +24,9 @@ import (
 func (p *Provider) Route(ctx context.Context, message *relayertypes.Message, callback relayertypes.TxResponseFunc) error {
 	p.log.Info("starting to route message",
 		zap.Any("sn", message.Sn),
-		zap.Any("req-id", message.ReqID),
+		zap.Any("req_id", message.ReqID),
 		zap.String("src", message.Src),
-		zap.String("event-type", message.EventType),
+		zap.String("event_type", message.EventType),
 		zap.String("data", hex.EncodeToString(message.Data)))
 
 	suiMessage, err := p.MakeSuiMessage(message)

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -160,7 +160,12 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayTypes.Last
 }
 
 func (p *Provider) Route(ctx context.Context, message *relayTypes.Message, callback relayTypes.TxResponseFunc) error {
-	p.logger.Info("starting to route message", zap.Any("message", message))
+	p.logger.Info("starting to route message",
+		zap.Any("sn", message.Sn),
+		zap.Any("req_id", message.ReqID),
+		zap.String("src", message.Src),
+		zap.String("event_type", message.EventType))
+
 	res, err := p.call(ctx, message)
 	if err != nil {
 		return err
@@ -693,9 +698,11 @@ func (p *Provider) getMessagesFromTxList(resultTxList []*coreTypes.ResultTx) ([]
 			msg.MessageHeight = uint64(resultTx.Height)
 			p.logger.Info("Detected eventlog",
 				zap.Uint64("height", msg.MessageHeight),
-				zap.String("target_network", msg.Dst),
+				zap.String("dst", msg.Dst),
 				zap.Uint64("sn", msg.Sn.Uint64()),
+				zap.Any("req_id", msg.ReqID),
 				zap.String("event_type", msg.EventType),
+				zap.String("tx_hash", resultTx.Hash.String()),
 			)
 		}
 		messages = append(messages, &relayTypes.BlockInfo{
@@ -814,8 +821,9 @@ func (p *Provider) SubscribeMessageEvents(ctx context.Context, blockInfoChan cha
 			for _, msg := range blockInfo.Messages {
 				p.logger.Info("Detected eventlog",
 					zap.Int64("height", res.Height),
-					zap.String("target_network", msg.Dst),
+					zap.String("dst", msg.Dst),
 					zap.Uint64("sn", msg.Sn.Uint64()),
+					zap.Any("req_id", msg.ReqID),
 					zap.String("event_type", msg.EventType),
 				)
 			}


### PR DESCRIPTION
Currently, in ICON while event log detection message data is not displayed and even while routing messages the message data is displayed in base64 string. So, in this PR, message data is logged while event log detection and data is displayed in hex format while message routing. Also, in the event monitoring API, the height that we get is one unit above the actual height in which event is published. So, the correct height is calculated in this PR. And since the tx-hash that we get in the event is not the tx-hash of transaction in which this event was published, it has been removed from the log.