### PR TITLE
feat: decouple sui dapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN ln sh pwd && \
     ln sh tar && \
     ln sh tee && \
     ln sh du && \
-    rm ln rm
+    rm ln
 
 # Install chain binaries
 COPY --from=build-env /go/bin/centralized-relay /bin

--- a/example/configs/sui.json
+++ b/example/configs/sui.json
@@ -1,32 +1,53 @@
 {
   "type": "sui",
   "value": {
-    "disabled": false,
     "nid": "sui-test",
-    "rpc-url": "https://fullnode.testnet.sui.io:443",
+    "rpc-url": "https://rpc.ankr.com/sui_testnet",
     "address": "0x07304a5d7d1a4763a1cea91f478d24e40aecf1fdbd2f14764d5ad745f4904f85",
     "xcall-package-ids": [
-      "0xd8acb58553eeefc32077075f4ee2a4dc7e9d65e0aa82639e12784043a0cffce1"
+      "0x8c5242ae42c53bdb92c94123184e72429283969772ec6e12e6f086bd673960b7",
+      "0x709f84ef9c9d486ef8bca12c4453413a3c2ef0c53a80d790abde71fc2cc2c6f3",
+      "0x693a60a5098b346acb773e37bff767fa90c85645ca9dba5d63741cf2bea848eb"
     ],
-    "xcall-storage-id": "0x4655bb7859023e6a8804f31cb746999d9e0758da642aa8e7e18e11c31427c8cc",
+    "xcall-storage-id": "0x60add4475c91742470074396ba29b6d62572abd1ac08c18abe228be949c21420",
     "connection-id": "centralized-1",
-    "connection-cap-id": "0x0bd3506ebbb37bb531342469c4665c3594442b6b004a8bb0e9910e5b04cc57ae",
-    "dapp-package-id": "0x7d7ae28c5a82c0bdb17a106dbbb236e3ee94e4b12408f04a0a192b20273fb2fd",
-    "dapp-modules": [
+    "connection-cap-id": "0x5e633b8baf655f4986a5d4b131ec316e8a9964108fd968c507c546cd92f78c27",
+    "dapps": [
       {
-        "name": "xcall_manager",
-        "cap-id": "0xa4ea25a8025e04543408e0ad054321ae98fda932bdf4ee846ba60f6548d64bcb",
-        "config-id": "0x85df6e0d192cb6f54e0fcdf681f34323a83ed4be871059c897a69eb2a466a34b"
+        "package-id": "0x28ffe81f26e9011809091dfd6b8ab7f2983ea2187b2a2641bd8f58ad7526247d",
+        "constants": {
+          "clock": "0x6"
+        },
+        "modules": [
+          {
+            "name": "xcall_manager",
+            "cap-id": "0xafa02d4592affcb14285a5dfd585ef5b47ad7ad68b4bbdcb659342915f8dd982",
+            "config-id": "0x1b8071a73e61a4b60e026875061311e9f9146d89ceb1120c35519f8e4dc47b2f"
+          },
+          {
+            "name": "asset_manager",
+            "cap-id": "0x0d7e657ed9e5494dccd2abcfec849d471bc43716a03a7b48b78bdc906b55535d",
+            "config-id": "0x323451f3f9526a54469f3d1db25d384dc5d9d20b63ad0db0bb42d62e0a0bf154"
+          },
+          {
+            "name": "balanced_dollar_crosschain",
+            "cap-id": "0xb3ffbef01bb8d5067ee36f2ddafac049ae62b7d4f70c349c9bb579b9a271e942",
+            "config-id": "0x1ecad1dfd5c22849414ba2f68113cc182a93ff01d9901c4800d0168ffd6e0cf5"
+          }
+        ]
       },
       {
-        "name": "asset_manager",
-        "cap-id": "0xb31546a6f3a0fa3b265f0572113d6422e81ae7fa455a615d27d2cab8ef85ab93",
-        "config-id": "0xb5605a51dae249aecd7d70352cf36f589c11822568774c144909110ebd15ee02"
-      },
-      {
-        "name": "balanced_dollar",
-        "cap-id": "0x630d4a826c090023600498c562a7dd611ef673268b7a4bd7de63c571684d97cf",
-        "config-id": "0x2427b3a3b95600749848e69f694ddffef5f96b2a0cc03e3d56d8a8b83ce94826"
+        "package-id": "0x5c582c88929cc177e7409dcc26e2c3e41502e4eec2c900b91ce1776dd0e87960",
+        "constants": {
+          "clock": "0x6"
+        },
+        "modules": [
+          {
+            "name": "mock_dapp",
+            "cap-id": "0x8f00fd59513fbe2af9bb275caa516a04e9172a7ae0de1b82821adb6a26dfdd32",
+            "config-id": "0xc3e007c8e2bfba62a150867d8de5e9557a3a31ba675409ee437ce9f9dcd08a31"
+          }
+        ]
       }
     ],
     "gas-limit": 5000000,

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	DappPkgID   string       `yaml:"dapp-package-id" json:"dapp-package-id"`
 	DappModules []DappModule `yaml:"dapp-modules" json:"dapp-modules"`
 
+	DappConstants DappConstants `yaml:"dapp-constants" json:"dapp-constants"`
+
 	HomeDir  string `yaml:"home-dir" json:"home-dir"`
 	GasLimit uint64 `yaml:"gas-limit" json:"gas-limit"`
 	Disabled bool   `json:"disabled" yaml:"disabled"`
@@ -42,6 +44,9 @@ type DappModule struct {
 	CapID    string `yaml:"cap-id" json:"cap-id"`
 	ConfigID string `yaml:"config-id" json:"config-id"`
 }
+
+// DappConstant is a map of name of sui constant to object id.
+type DappConstants map[string]string
 
 func (pc *Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath string, debug bool, chainName string) (provider.ChainProvider, error) {
 	pc.HomeDir = homePath

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -24,11 +24,6 @@ type Config struct {
 	ConnectionID    string `yaml:"connection-id" json:"connection-id"`
 	ConnectionCapID string `yaml:"connection-cap-id" json:"connection-cap-id"`
 
-	DappPkgID   string       `yaml:"dapp-package-id" json:"dapp-package-id"`
-	DappModules []DappModule `yaml:"dapp-modules" json:"dapp-modules"`
-
-	DappConstants DappConstants `yaml:"dapp-constants" json:"dapp-constants"`
-
 	Dapps []Dapp `yaml:"dapps" json:"dapps"`
 
 	HomeDir  string `yaml:"home-dir" json:"home-dir"`
@@ -55,8 +50,6 @@ type Dapp struct {
 
 	Modules []DappModule `json:"modules" yaml:"modules"`
 }
-
-type DappConstants map[string]string
 
 func (pc *Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath string, debug bool, chainName string) (provider.ChainProvider, error) {
 	pc.HomeDir = homePath

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -29,6 +29,8 @@ type Config struct {
 
 	DappConstants DappConstants `yaml:"dapp-constants" json:"dapp-constants"`
 
+	Dapps []Dapp `yaml:"dapps" json:"dapps"`
+
 	HomeDir  string `yaml:"home-dir" json:"home-dir"`
 	GasLimit uint64 `yaml:"gas-limit" json:"gas-limit"`
 	Disabled bool   `json:"disabled" yaml:"disabled"`
@@ -45,7 +47,15 @@ type DappModule struct {
 	ConfigID string `yaml:"config-id" json:"config-id"`
 }
 
-// DappConstant is a map of name of sui constant to object id.
+type Dapp struct {
+	PkgID string `json:"package-id" yaml:"package-id"`
+
+	// DappConstant is a map of name of sui constant to object id.
+	Constants map[string]string `json:"constants" yaml:"constants"`
+
+	Modules []DappModule `json:"modules" yaml:"modules"`
+}
+
 type DappConstants map[string]string
 
 func (pc *Config) NewProvider(ctx context.Context, logger *zap.Logger, homePath string, debug bool, chainName string) (provider.ChainProvider, error) {

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -50,7 +50,7 @@ func (p *Provider) allowedEventTypes() []string {
 
 func (p *Provider) shouldSkipMessage(msg *relayertypes.Message) bool {
 	// if relayer is not an executor then skip CallMessage and RollbackMessage events.
-	if p.cfg.DappPkgID == "" &&
+	if len(p.cfg.Dapps) == 0 &&
 		(msg.EventType == relayerEvents.CallMessage ||
 			msg.EventType == relayerEvents.RollbackMessage) {
 		return true

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -16,32 +16,26 @@ import (
 )
 
 var (
-	MethodClaimFee             = "claim_fees"
-	MethodGetReceipt           = "get_receipt"
-	MethodSetFee               = "set_fee"
-	MethodGetFee               = "get_fee"
-	MethodRevertMessage        = "revert_message"
-	MethodSetAdmin             = "set_admin"
-	MethodGetAdmin             = "get_admin"
-	MethodRecvMessage          = "receive_message"
-	MethodExecuteCall          = "execute_call"
-	MethodExecuteRollback      = "execute_rollback"
-	MethodGetWithdrawTokentype = "get_withdraw_token_type"
+	MethodClaimFee                 = "claim_fees"
+	MethodGetReceipt               = "get_receipt"
+	MethodSetFee                   = "set_fee"
+	MethodGetFee                   = "get_fee"
+	MethodRevertMessage            = "revert_message"
+	MethodSetAdmin                 = "set_admin"
+	MethodGetAdmin                 = "get_admin"
+	MethodRecvMessage              = "receive_message"
+	MethodExecuteCall              = "execute_call"
+	MethodExecuteRollback          = "execute_rollback"
+	MethodGetWithdrawTokentype     = "get_withdraw_token_type"
+	MethodGetExecuteCallParams     = "get_execute_params"
+	MethodGetExecuteRollbackParams = "get_rollback_params"
 
 	ModuleConnection = "centralized_connection"
 	ModuleEntry      = "centralized_entry"
 	ModuleMain       = "main"
 	XcallModule      = "xcall"
 
-	ModuleMockDapp       = "mock_dapp"
-	ModuleXcallManager   = "xcall_manager"
-	ModuleAssetManager   = "asset_manager"
-	ModuleBalancedDollar = "balanced_dollar_crosschain"
-
 	suiCurrencyDenom = "SUI"
-	suiBaseFee       = 1000
-
-	suiClockObjectId = "0x6"
 )
 
 type Provider struct {

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -36,6 +36,7 @@ var (
 	XcallModule      = "xcall"
 
 	suiCurrencyDenom = "SUI"
+	suiBaseFee       = 1000
 )
 
 type Provider struct {

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fardream/go-bcs/bcs"
 	"github.com/icon-project/centralized-relay/relayer/events"
 	relayertypes "github.com/icon-project/centralized-relay/relayer/types"
+	"github.com/icon-project/centralized-relay/utils/hexstr"
 	"go.uber.org/zap"
 )
 
@@ -101,7 +102,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 func (p *Provider) getModule(moduleCapID string) (*Dapp, *DappModule, error) {
 	for _, dapp := range p.cfg.Dapps {
 		for _, mod := range dapp.Modules {
-			if mod.CapID == moduleCapID {
+			if hexstr.NewFromString(mod.CapID) == hexstr.NewFromString(moduleCapID) {
 				return &dapp, &mod, nil
 			}
 		}

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -443,7 +443,7 @@ func (p *Provider) getExecuteParams(
 					return nil, nil, err
 				}
 				callArgs = append(callArgs, SuiCallArg{
-					Type: CallArgObject, Val: coin,
+					Type: CallArgObject, Val: coin.CoinObjectId.String(),
 				})
 			case "sn":
 				snU128, err := bcs.NewUint128FromBigInt(message.Sn)

--- a/test/chains/sui/remotenet.go
+++ b/test/chains/sui/remotenet.go
@@ -172,8 +172,8 @@ func (an *SuiRemotenet) DeployXCallMockApp(ctx context.Context, keyName string, 
 		params = []SuiCallArg{
 			{Type: CallArgObject, Val: an.IBCAddresses[dappKey+StateSuffix]},
 			{Type: CallArgPure, Val: connection.Nid},
-			{Type: CallArgPure, Val: connectionName},
-			{Type: CallArgPure, Val: connection.Destination},
+			{Type: CallArgPure, Val: []string{connectionName}},
+			{Type: CallArgPure, Val: []string{connection.Destination}},
 		}
 
 		msg = an.NewSuiMessage(params, an.IBCAddresses[dappKey], MockAppModule, "add_connection")
@@ -543,11 +543,10 @@ func (an *SuiRemotenet) SetupXCall(ctx context.Context) error {
 	params = []SuiCallArg{
 		{Type: CallArgObject, Val: an.IBCAddresses[xcallStorage]},
 		{Type: CallArgObject, Val: an.IBCAddresses[xcallAdmin]},
-		{Type: CallArgPure, Val: "sui"},
 		{Type: CallArgPure, Val: connectionName},
 		{Type: CallArgPure, Val: an.testconfig.RelayWalletAddress},
 	}
-	msg = an.NewSuiMessage(params, an.IBCAddresses["xcall"], "main", "register_connection")
+	msg = an.NewSuiMessage(params, an.IBCAddresses["xcall"], "main", "register_connection_admin")
 	resp, err := an.callContract(ctx, msg)
 	if err != nil {
 		return err

--- a/test/chains/sui/remotenet.go
+++ b/test/chains/sui/remotenet.go
@@ -344,8 +344,8 @@ func (an *SuiRemotenet) GetRelayConfig(ctx context.Context, rlyHome string, keyN
 	contracts["xcall"] = an.GetContractAddress("xcall")
 	dappModule := centralized.SuiDappModule{
 		Name:     MockAppModule,
-		CapId:    an.GetContractAddress(dappKey + IdCapSuffix)[2:],
-		ConfigId: an.GetContractAddress(dappKey + StateSuffix),
+		CapID:    an.GetContractAddress(dappKey + IdCapSuffix)[2:],
+		ConfigID: an.GetContractAddress(dappKey + StateSuffix),
 	}
 	config := &centralized.SUIRelayerChainConfig{
 		Type: "sui",
@@ -357,9 +357,13 @@ func (an *SuiRemotenet) GetRelayConfig(ctx context.Context, rlyHome string, keyN
 			XcallStorageId:  an.GetContractAddress(xcallStorage),
 			ConnectionId:    an.GetContractAddress("connection"),
 			ConnectionCapId: an.GetContractAddress("connectionCap"),
-			DappPkgId:       an.GetContractAddress(dappKey),
-			DappModules: []centralized.SuiDappModule{
-				dappModule,
+			Dapps: []centralized.SuiDapp{
+				{
+					PkgID: an.GetContractAddress(dappKey),
+					Modules: []centralized.SuiDappModule{
+						dappModule,
+					},
+				},
 			},
 			StartHeight:   0,
 			BlockInterval: "0s",

--- a/test/interchaintest/relayer/centralized/centralized_relayer.go
+++ b/test/interchaintest/relayer/centralized/centralized_relayer.go
@@ -79,9 +79,6 @@ type SuiDappModule struct {
 type SuiDapp struct {
 	PkgID string `json:"package-id" yaml:"package-id"`
 
-	// DappConstant is a map of name of sui constant to object id.
-	Constants map[string]string `json:"constants" yaml:"constants"`
-
 	Modules []SuiDappModule `json:"modules" yaml:"modules"`
 }
 

--- a/test/interchaintest/relayer/centralized/centralized_relayer.go
+++ b/test/interchaintest/relayer/centralized/centralized_relayer.go
@@ -53,28 +53,36 @@ type ICONRelayerChainConfigValue struct {
 }
 
 type SUIRelayerChainConfigValue struct {
-	NID             string          `yaml:"nid"`
-	RPCURL          string          `yaml:"rpc-url"`
-	WebsocketUrl    string          `yaml:"ws-url"`
-	StartHeight     int             `yaml:"start-height"`
-	XcallPkgIds     []string        `yaml:"xcall-package-ids"`
-	ConnectionId    string          `yaml:"connection-id"`
-	ConnectionCapId string          `yaml:"connection-cap-id"`
-	DappPkgId       string          `yaml:"dapp-package-id"`
-	XcallStorageId  string          `yaml:"xcall-storage-id"`
-	NetworkID       int             `yaml:"network-id"`
-	BlockInterval   string          `yaml:"block-interval"`
-	Address         string          `yaml:"address"`
-	FinalityBlock   uint64          `yaml:"finality-block"`
-	GasPrice        int64           `yaml:"gas-price"`
-	GasLimit        int             `yaml:"gas-limit"`
-	DappModules     []SuiDappModule `yaml:"dapp-modules"`
+	NID             string    `yaml:"nid"`
+	RPCURL          string    `yaml:"rpc-url"`
+	WebsocketUrl    string    `yaml:"ws-url"`
+	StartHeight     int       `yaml:"start-height"`
+	XcallPkgIds     []string  `yaml:"xcall-package-ids"`
+	ConnectionId    string    `yaml:"connection-id"`
+	ConnectionCapId string    `yaml:"connection-cap-id"`
+	XcallStorageId  string    `yaml:"xcall-storage-id"`
+	NetworkID       int       `yaml:"network-id"`
+	BlockInterval   string    `yaml:"block-interval"`
+	Address         string    `yaml:"address"`
+	FinalityBlock   uint64    `yaml:"finality-block"`
+	GasPrice        int64     `yaml:"gas-price"`
+	GasLimit        int       `yaml:"gas-limit"`
+	Dapps           []SuiDapp `yaml:"dapps"`
 }
 
 type SuiDappModule struct {
-	Name     string `yaml:"name"`
-	CapId    string `yaml:"cap-id"`
-	ConfigId string `yaml:"config-id"`
+	Name     string `yaml:"name" json:"name"`
+	CapID    string `yaml:"cap-id" json:"cap-id"`
+	ConfigID string `yaml:"config-id" json:"config-id"`
+}
+
+type SuiDapp struct {
+	PkgID string `json:"package-id" yaml:"package-id"`
+
+	// DappConstant is a map of name of sui constant to object id.
+	Constants map[string]string `json:"constants" yaml:"constants"`
+
+	Modules []SuiDappModule `json:"modules" yaml:"modules"`
 }
 
 type EVMRelayerChainConfigValue struct {


### PR DESCRIPTION
Previously relayer was tightly coupled wilth specific dapp related information like module name and so on. Also, a single dapp could only be configured in the relayer from the config. So, in this PR the following features have been implemented:
- Relayer does not need to know dapp specific information.
- Also multiple dapp could be added in the relayer from the config itself.