### PR TITLE
fix: conn reset packet cleaned

### DIFF
--- a/relayer/chains/evm/listener.go
+++ b/relayer/chains/evm/listener.go
@@ -69,18 +69,20 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 			p.log.Debug("evm listener: done")
 			return ctx.Err()
 		case err := <-errChan:
-			p.log.Error("connection error", zap.Error(err))
-			clientReconnected := false
-			for !clientReconnected {
-				p.log.Info("reconnecting client")
-				client, err := p.client.Reconnect()
-				if err == nil {
-					clientReconnected = true
-					p.log.Info("client reconnected")
-					p.client = client
-				} else {
-					p.log.Error("failed to re-connect", zap.Error(err))
-					time.Sleep(ClientReconnectDelay)
+			if p.isConnectionError(err) {
+				p.log.Error("connection error", zap.Error(err))
+				clientReconnected := false
+				for !clientReconnected {
+					p.log.Info("reconnecting client")
+					client, err := p.client.Reconnect()
+					if err == nil {
+						clientReconnected = true
+						p.log.Info("client reconnected")
+						p.client = client
+					} else {
+						p.log.Error("failed to re-connect", zap.Error(err))
+						time.Sleep(ClientReconnectDelay)
+					}
 				}
 			}
 			startHeight = p.GetLastSavedBlockHeight()
@@ -162,7 +164,9 @@ func (p *Provider) getLogsRetry(ctx context.Context, filter ethereum.FilterQuery
 }
 
 func (p *Provider) isConnectionError(err error) bool {
-	return strings.Contains(err.Error(), "tcp") || errors.Is(err, context.DeadlineExceeded)
+	return strings.Contains(err.Error(), "tcp") ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(err.Error(), "websocket")
 }
 
 func (p *Provider) FindMessages(ctx context.Context, lbn *types.BlockNotification) ([]*relayertypes.Message, error) {
@@ -229,7 +233,7 @@ func (p *Provider) startFromHeight(ctx context.Context, lastSavedHeight uint64) 
 // Subscribe listens to new blocks and sends them to the channel
 func (p *Provider) Subscribe(ctx context.Context, blockInfoChan chan *relayertypes.BlockInfo, resetCh chan error) error {
 	ch := make(chan ethTypes.Log, 10)
-	subContext, cancel := context.WithTimeout(ctx, time.Second*10)
+	subContext, cancel := context.WithTimeout(ctx, websocketReadTimeout)
 	defer cancel()
 	sub, err := p.client.Subscribe(subContext, ethereum.FilterQuery{
 		Addresses: p.blockReq.Addresses,

--- a/relayer/store/messageStore_test.go
+++ b/relayer/store/messageStore_test.go
@@ -59,8 +59,7 @@ func TestMessageStoreSet(t *testing.T) {
 	t.Run("getMessage", func(t *testing.T) {
 		getMessage, err := messageStore.GetMessage(types.NewMessageKey(Sn, nId, "", "emitMessage"))
 		assert.NoError(t, err, " error occured while getting message")
-		assert.Equal(t, getMessage, types.NewRouteMessage(storeMessage))
-
+		assert.Equal(t, getMessage.Message, types.NewRouteMessage(storeMessage).Message)
 		if err := testdb.ClearStore(); err != nil {
 			assert.Fail(t, "failed to clear db ", err)
 		}

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -80,6 +80,7 @@ type RouteMessage struct {
 func NewRouteMessage(m *Message) *RouteMessage {
 	return &RouteMessage{
 		Message: m,
+		LastTry: time.Now(),
 	}
 }
 


### PR DESCRIPTION
Few issues are addressed here:
- For websocket errors, the client is not reset and when subscribing, since default context is passed the subscription waited for 4 hours in some cases to report failure and worked only after that. The error has been added to the client recon list and the context also has been modified to use the websocket timeout context.
- The route message have a default lastTry of 0 which is set to current time only after the routing is tried. For emit messages, it is first checked if it has already been submitted before and in this case where the connection is not working, the lastTry may not be set for long period of time enough for the cleaner thread to clean these pending requests. This has been fixed by having a default value of current time.