### PR TITLE
fix: sui enhancements

### DIFF
--- a/example/configs/sui.json
+++ b/example/configs/sui.json
@@ -4,11 +4,7 @@
     "nid": "sui-test",
     "rpc-url": "https://rpc.ankr.com/sui_testnet",
     "address": "0x07304a5d7d1a4763a1cea91f478d24e40aecf1fdbd2f14764d5ad745f4904f85",
-    "xcall-package-ids": [
-      "0x8c5242ae42c53bdb92c94123184e72429283969772ec6e12e6f086bd673960b7",
-      "0x709f84ef9c9d486ef8bca12c4453413a3c2ef0c53a80d790abde71fc2cc2c6f3",
-      "0x693a60a5098b346acb773e37bff767fa90c85645ca9dba5d63741cf2bea848eb"
-    ],
+    "xcall-package-id": "0x8c5242ae42c53bdb92c94123184e72429283969772ec6e12e6f086bd673960b7",
     "xcall-storage-id": "0x60add4475c91742470074396ba29b6d62572abd1ac08c18abe228be949c21420",
     "connection-id": "centralized-1",
     "connection-cap-id": "0x5e633b8baf655f4986a5d4b131ec316e8a9964108fd968c507c546cd92f78c27",
@@ -51,6 +47,7 @@
       }
     ],
     "gas-limit": 5000000,
-    "start-tx-digest": ""
+    "start-tx-digest": "",
+    "poll-interval": "6s"
   }
 }

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -18,9 +18,8 @@ type Config struct {
 	Address   string `yaml:"address" json:"address"`
 	NID       string `yaml:"nid" json:"nid"`
 
-	// list of xcall package ids in order of latest to oldest in descending order
-	XcallPkgIDs    []string `yaml:"xcall-package-ids" json:"xcall-package-ids"`
-	XcallStorageID string   `yaml:"xcall-storage-id" json:"xcall-storage-id"`
+	XcallPkgID     string `yaml:"xcall-package-id" json:"xcall-package-id"`
+	XcallStorageID string `yaml:"xcall-storage-id" json:"xcall-storage-id"`
 
 	ConnectionID    string `yaml:"connection-id" json:"connection-id"`
 	ConnectionCapID string `yaml:"connection-cap-id" json:"connection-cap-id"`

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -3,6 +3,7 @@ package sui
 import (
 	"context"
 	"sync"
+	"time"
 
 	suisdkClient "github.com/coming-chat/go-sui/v2/client"
 	"github.com/icon-project/centralized-relay/relayer/provider"
@@ -34,6 +35,8 @@ type Config struct {
 	// Should be empty if we want to query using last saved tx-digest
 	// from database.
 	StartTxDigest string `json:"start-tx-digest" yaml:"start-tx-digest"`
+
+	PollInterval time.Duration `json:"poll-interval" yaml:"poll-interval"`
 }
 
 type DappModule struct {

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -34,18 +34,6 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx relayertypes.La
 	return p.listenByPolling(ctx, txInfo.TxDigest, blockInfo)
 }
 
-func (p *Provider) allowedEventTypes() []string {
-	allowedEvents := []string{}
-	for _, xcallPkgId := range p.cfg.XcallPkgIDs {
-		allowedEvents = append(allowedEvents, []string{
-			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleConnection, "Message"),
-			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleMain, "CallMessage"),
-			fmt.Sprintf("%s::%s::%s", xcallPkgId, ModuleMain, "RollbackMessage"),
-		}...)
-	}
-	return allowedEvents
-}
-
 func (p *Provider) shouldSkipMessage(msg *relayertypes.Message) bool {
 	// if relayer is not an executor then skip CallMessage and RollbackMessage events.
 	if len(p.cfg.Dapps) == 0 &&

--- a/relayer/chains/sui/listener.go
+++ b/relayer/chains/sui/listener.go
@@ -188,7 +188,7 @@ func (p *Provider) parseMessageFromEvent(ev types.EventResponse) (*relayertypes.
 func (p *Provider) handleEventNotification(ctx context.Context, ev types.EventResponse, blockStream chan *relayertypes.BlockInfo) {
 	for ev.Checkpoint == nil {
 		p.log.Warn("checkpoint not found for transaction", zap.String("tx-digest", ev.Id.TxDigest.String()))
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 		txRes, err := p.client.GetTransaction(ctx, ev.Id.TxDigest.String())
 		if err != nil {
 			p.log.Error("failed to get transaction while handling event notification",

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -111,7 +111,7 @@ func (p *Provider) GenerateMessages(ctx context.Context, messageKey *relayertype
 		checkpoint.Transactions,
 		func(stbr *suitypes.SuiTransactionBlockResponse) bool {
 			for _, t := range stbr.ObjectChanges {
-				if t.Data.Mutated.ObjectId.String() == p.cfg.XcallStorageID {
+				if t.Data.Mutated != nil && t.Data.Mutated.ObjectId.String() == p.cfg.XcallStorageID {
 					return true
 				}
 			}

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/coming-chat/go-sui/v2/account"
+	suitypes "github.com/coming-chat/go-sui/v2/types"
 	"github.com/icon-project/centralized-relay/relayer/chains/sui/types"
 	"github.com/icon-project/centralized-relay/relayer/kms"
 	"github.com/icon-project/centralized-relay/relayer/provider"
@@ -105,7 +106,18 @@ func (p *Provider) GenerateMessages(ctx context.Context, messageKey *relayertype
 
 	var messages []*relayertypes.Message
 
-	eventResponse, err := p.client.GetEventsFromTxBlocks(ctx, p.allowedEventTypes(), checkpoint.Transactions)
+	eventResponse, err := p.client.GetEventsFromTxBlocks(
+		ctx,
+		checkpoint.Transactions,
+		func(stbr *suitypes.SuiTransactionBlockResponse) bool {
+			for _, t := range stbr.ObjectChanges {
+				if t.Data.Mutated.ObjectId.String() == p.cfg.XcallStorageID {
+					return true
+				}
+			}
+			return false
+		},
+	)
 	if err != nil {
 		p.log.Error("failed to query events", zap.Error(err))
 		return nil, err
@@ -143,7 +155,7 @@ func (p *Provider) GetFee(ctx context.Context, networkID string, responseFee boo
 			{Type: CallArgPure, Val: p.cfg.ConnectionID},
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: responseFee},
-		}, p.xcallPkgIDLatest(), ModuleEntry, MethodGetFee)
+		}, p.cfg.XcallPkgID, ModuleEntry, MethodGetFee)
 	var fee uint64
 	wallet, err := p.Wallet()
 	if err != nil {
@@ -168,7 +180,7 @@ func (p *Provider) SetFee(ctx context.Context, networkID string, msgFee, resFee 
 			{Type: CallArgPure, Val: networkID},
 			{Type: CallArgPure, Val: strconv.Itoa(int(msgFee.Int64()))},
 			{Type: CallArgPure, Val: strconv.Itoa(int(resFee.Int64()))},
-		}, p.xcallPkgIDLatest(), ModuleEntry, MethodSetFee)
+		}, p.cfg.XcallPkgID, ModuleEntry, MethodSetFee)
 	txBytes, err := p.prepareTxMoveCall(suiMessage)
 	if err != nil {
 		return err
@@ -191,7 +203,7 @@ func (p *Provider) ClaimFee(ctx context.Context) error {
 			{Type: CallArgObject, Val: p.cfg.XcallStorageID},
 			{Type: CallArgObject, Val: p.cfg.ConnectionCapID},
 		},
-		p.xcallPkgIDLatest(), ModuleEntry, MethodClaimFee)
+		p.cfg.XcallPkgID, ModuleEntry, MethodClaimFee)
 	txBytes, err := p.prepareTxMoveCall(suiMessage)
 	if err != nil {
 		return err
@@ -220,8 +232,4 @@ func (p *Provider) ShouldReceiveMessage(ctx context.Context, messagekey *relayer
 
 func (p *Provider) ShouldSendMessage(ctx context.Context, messageKey *relayertypes.Message) (bool, error) {
 	return true, nil
-}
-
-func (p *Provider) xcallPkgIDLatest() string {
-	return p.cfg.XcallPkgIDs[0]
 }

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -64,7 +64,7 @@ func (p *Provider) MakeSuiMessage(message *relayertypes.Message) (*SuiMessage, e
 			{Type: CallArgPure, Val: snU128},
 			{Type: CallArgPure, Val: "0x" + hex.EncodeToString(message.Data)},
 		}
-		return p.NewSuiMessage([]string{}, callParams, p.xcallPkgIDLatest(), ModuleEntry, MethodRecvMessage), nil
+		return p.NewSuiMessage([]string{}, callParams, p.cfg.XcallPkgID, ModuleEntry, MethodRecvMessage), nil
 	case events.CallMessage:
 		if _, err := p.Wallet(); err != nil {
 			return nil, err
@@ -361,7 +361,7 @@ func (p *Provider) MessageReceived(ctx context.Context, messageKey *relayertypes
 				{Type: CallArgPure, Val: p.cfg.ConnectionID},
 				{Type: CallArgPure, Val: messageKey.Src},
 				{Type: CallArgPure, Val: snU128},
-			}, p.xcallPkgIDLatest(), ModuleEntry, MethodGetReceipt)
+			}, p.cfg.XcallPkgID, ModuleEntry, MethodGetReceipt)
 		var msgReceived bool
 		wallet, err := p.Wallet()
 		if err != nil {

--- a/relayer/socket/server.go
+++ b/relayer/socket/server.go
@@ -178,11 +178,14 @@ func (s *Server) parseEvent(msg *Message) (*Message, error) {
 			for _, msg := range msgs {
 				src.MessageCache.Add(types.NewRouteMessage(msg))
 			}
-			data, err := jsoniter.Marshal(&ResRelayMessage{types.NewRouteMessage(msgs[0])})
-			if err != nil {
-				return nil, err
+			if len(msgs) > 0 {
+				data, err := jsoniter.Marshal(&ResRelayMessage{types.NewRouteMessage(msgs[0])})
+				if err != nil {
+					return nil, err
+				}
+				return &Message{EventRelayMessage, data}, nil
 			}
-			return &Message{EventRelayMessage, data}, nil
+			return &Message{EventRelayMessage, []byte{}}, nil
 		}
 
 		store := s.rly.GetMessageStore()

--- a/test/chains/sui/remotenet.go
+++ b/test/chains/sui/remotenet.go
@@ -353,7 +353,7 @@ func (an *SuiRemotenet) GetRelayConfig(ctx context.Context, rlyHome string, keyN
 			NID:             an.Config().ChainID,
 			RPCURL:          an.GetRPCAddress(),
 			WebsocketUrl:    an.testconfig.WebsocketUrl,
-			XcallPkgIds:     []string{an.GetContractAddress("xcall")},
+			XcallPkgId:      an.GetContractAddress("xcall"),
 			XcallStorageId:  an.GetContractAddress(xcallStorage),
 			ConnectionId:    an.GetContractAddress("connection"),
 			ConnectionCapId: an.GetContractAddress("connectionCap"),

--- a/test/interchaintest/relayer/centralized/centralized_relayer.go
+++ b/test/interchaintest/relayer/centralized/centralized_relayer.go
@@ -57,7 +57,7 @@ type SUIRelayerChainConfigValue struct {
 	RPCURL          string    `yaml:"rpc-url"`
 	WebsocketUrl    string    `yaml:"ws-url"`
 	StartHeight     int       `yaml:"start-height"`
-	XcallPkgIds     []string  `yaml:"xcall-package-ids"`
+	XcallPkgId      string    `yaml:"xcall-package-id"`
 	ConnectionId    string    `yaml:"connection-id"`
 	ConnectionCapId string    `yaml:"connection-cap-id"`
 	XcallStorageId  string    `yaml:"xcall-storage-id"`


### PR DESCRIPTION
Currently, we are fetching 100 transactions per page containing events from RPC at an interval of 3s. In this setting, we are facing the following issues:
1. The transaction received from the query is not yet included in the checkpoint.
2. Sometimes, we are also missing some events.

So, to reduce the probability of facing these issues, we can try the following setting:
1. Make the query interval configurable from the chain config to restart the relayer with the desired interval whenever required.
2. Set transactions per page while querying to 15.

This setting might increase the probability of transaction digests being included in the checkpoint and reduce the chances of missing events.


Also, currently, in the relayer, we are storing all the old and upgraded package ids of Xcall. Initially we did this to filter the events from the all the packages. But now, it seems we can filter events just by checking if the transaction block contains the xcall storage object id in the object changes list. So, we should be saving only the most recent upgraded xcall package in the SUI config in the relayer.