### PR TITLE
feat: added cluster configs for relayer

### DIFF
--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -11,6 +11,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/icon-project/centralized-relay/relayer"
+	"github.com/icon-project/centralized-relay/relayer/provider"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -162,6 +163,7 @@ func addChainFromFile(a *appState, chainName string, file string) error {
 	if err != nil {
 		return fmt.Errorf("failed to build ChainProvider for %s: %w", file, err)
 	}
+	prov.Config().(provider.ClusterConfig).SetClusterMode(a.config.Global.ClusterMode)
 
 	c := relayer.NewChain(a.log, prov, a.debug)
 	if err = a.config.AddChain(c); err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -129,8 +129,9 @@ $ %s cfg i`, appName, a.homePath, appName)),
 
 // GlobalConfig describes any global relayer settings
 type GlobalConfig struct {
-	Timeout  string `yaml:"timeout" json:"timeout"`
-	KMSKeyID string `yaml:"kms-key-id" json:"kms-key-id"`
+	Timeout     string `yaml:"timeout" json:"timeout"`
+	KMSKeyID    string `yaml:"kms-key-id" json:"kms-key-id"`
+	ClusterMode bool   `yaml:"cluster-mode" json:"cluster-mode"`
 }
 
 // newDefaultGlobalConfig returns a global config with defaults set
@@ -187,6 +188,7 @@ func (c *ConfigInputWrapper) RuntimeConfig(ctx context.Context, a *appState) (*C
 		if err != nil {
 			return nil, fmt.Errorf("failed to build ChainProviders: %w", err)
 		}
+		prov.Config().(provider.ClusterConfig).SetClusterMode(c.Global.ClusterMode)
 		kmsProvider, err := kms.NewKMSConfig(context.Background(), &c.Global.KMSKeyID)
 		if err != nil {
 			return nil, err

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -262,7 +262,7 @@ func (d *dbState) getRelayer(app *appState) (*relayer.Relayer, error) {
 	if err != nil {
 		return nil, err
 	}
-	rly, err := relayer.NewRelayer(app.log, db, app.config.Chains.GetAll(), false)
+	rly, err := relayer.NewRelayer(app.log, db, app.config.Chains.GetAll(), false, false)
 	if err != nil {
 		fmt.Printf("failed to create relayer: %s\n", err)
 		return nil, err

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -41,7 +41,7 @@ func startCmd(a *appState) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			rly, err := relayer.NewRelayer(a.log, db, chains, fresh)
+			rly, err := relayer.NewRelayer(a.log, db, chains, fresh, a.config.Global.ClusterMode)
 			if err != nil {
 				return fmt.Errorf("error creating new relayer %v", err)
 			}

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -18,6 +18,11 @@ type Config interface {
 	Enabled() bool
 }
 
+type ClusterConfig interface {
+	SetClusterMode(bool)
+	GetClusterMode() bool
+}
+
 type ChainQuery interface {
 	QueryLatestHeight(ctx context.Context) (uint64, error)
 	QueryTransactionReceipt(ctx context.Context, txHash string) (*types.Receipt, error)
@@ -62,6 +67,7 @@ type CommonConfig struct {
 	NID           string                  `json:"nid" yaml:"nid"`
 	HomeDir       string                  `json:"-" yaml:"-"`
 	Disabled      bool                    `json:"disabled" yaml:"disabled"`
+	ClusterMode   bool                    `yaml:"cluster-mode" json:"cluster-mode"`
 }
 
 // Enabled returns true if the provider is enabled
@@ -86,4 +92,12 @@ func (pc *CommonConfig) Validate() error {
 		return fmt.Errorf("home-dir cannot be empty")
 	}
 	return nil
+}
+
+func (c *CommonConfig) SetClusterMode(mode bool) {
+	c.ClusterMode = mode
+}
+
+func (c *CommonConfig) GetClusterMode() bool {
+	return c.ClusterMode
 }

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -61,9 +61,10 @@ type Relayer struct {
 	blockStore           *store.BlockStore
 	finalityStore        *store.FinalityStore
 	lastProcessedTxStore *store.LastProcessedTxStore
+	clusterMode          bool
 }
 
-func NewRelayer(log *zap.Logger, db store.Store, chains map[string]*Chain, fresh bool) (*Relayer, error) {
+func NewRelayer(log *zap.Logger, db store.Store, chains map[string]*Chain, fresh, clusterMode bool) (*Relayer, error) {
 	// if fresh clearing db
 	if fresh {
 		if err := db.ClearStore(); err != nil {
@@ -109,6 +110,7 @@ func NewRelayer(log *zap.Logger, db store.Store, chains map[string]*Chain, fresh
 		blockStore:           blockStore,
 		finalityStore:        finalityStore,
 		lastProcessedTxStore: lastProcessedTxStore,
+		clusterMode:          clusterMode,
 	}, nil
 }
 

--- a/relayer/relay_test.go
+++ b/relayer/relay_test.go
@@ -111,7 +111,7 @@ func (s *RelayTestSuite) TestRelay() {
 	chains[mock2Nid] = NewChain(logger, mock2Provider, true)
 
 	ctx := context.Background()
-	rly, err := NewRelayer(logger, s.db, chains, true)
+	rly, err := NewRelayer(logger, s.db, chains, true, false)
 	if err != nil {
 		s.Fail("unable to start the relayer ", err)
 	}


### PR DESCRIPTION
added `cluster-mode` config in the relayer to indicate cluster mode setup and passed the params to providers as well as relayers.