### PR TITLE
feat: initial event sign interaction

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,9 +178,6 @@ func (c *ConfigInputWrapper) RuntimeConfig(ctx context.Context, a *appState) (*C
 	// build providers for each chain
 	chains := make(relayer.Chains)
 	for chainName, pcfg := range c.ProviderConfigs {
-		if !pcfg.Value.(provider.Config).Enabled() {
-			continue
-		}
 		prov, err := pcfg.Value.(provider.Config).NewProvider(ctx,
 			a.log.With(zap.Stringp("provider_type", &pcfg.Type)),
 			a.homePath, a.debug, chainName,

--- a/relayer/chains/evm/provider.go
+++ b/relayer/chains/evm/provider.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -478,4 +479,19 @@ func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
 // GetLastSavedBlockHeight returns the last saved block height
 func (p *Provider) GetLastSavedBlockHeight() uint64 {
 	return p.LastSavedHeightFunc()
+}
+
+func (p *Config) GetConncontract() string {
+	return p.Contracts[providerTypes.ConnectionContract]
+}
+
+func (p *Provider) SignMessage(message []byte) ([]byte, error) {
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write([]byte("\x19Ethereum Signed Message:\n" + fmt.Sprint(len(message)) + string(message)))
+	messageHash := hash.Sum(nil)
+	wallet, err := p.Wallet()
+	if err != nil {
+		return nil, err
+	}
+	return crypto.Sign(messageHash, wallet.PrivateKey)
 }

--- a/relayer/chains/icon/events.go
+++ b/relayer/chains/icon/events.go
@@ -8,9 +8,10 @@ import (
 
 // All the events
 const (
-	EmitMessage     = "Message(str,int,bytes)"
-	CallMessage     = "CallMessage(str,str,int,int,bytes)"
-	RollbackMessage = "RollbackMessage(int)"
+	EmitMessage        = "Message(str,int,bytes)"
+	CallMessage        = "CallMessage(str,str,int,int,bytes)"
+	RollbackMessage    = "RollbackMessage(int)"
+	AcknowledgeMessage = "PacketAcknowledged(int,str,int,bytes,str)"
 )
 
 // EventSigToEventType converts event signature to event type
@@ -26,6 +27,10 @@ func (p *Config) eventMap() map[string]providerTypes.EventMap {
 			}
 		case providerTypes.ConnectionContract:
 			event.SigType = map[string]string{EmitMessage: events.EmitMessage}
+		case providerTypes.AggregationContract:
+			event.SigType = map[string]string{
+				AcknowledgeMessage: events.AcknowledgeMessage,
+			}
 		}
 		eventMap[addr] = event
 	}

--- a/relayer/chains/icon/listener.go
+++ b/relayer/chains/icon/listener.go
@@ -88,6 +88,7 @@ func (p *Provider) Listener(ctx context.Context, lastProcessedTx providerTypes.L
 						}
 						for _, msg := range msgs {
 							p.log.Info("Detected eventlog",
+								zap.String("src", msg.Src),
 								zap.String("dst", msg.Dst),
 								zap.Uint64("sn", msg.Sn.Uint64()),
 								zap.Any("req_id", msg.ReqID),

--- a/relayer/chains/icon/methods.go
+++ b/relayer/chains/icon/methods.go
@@ -14,4 +14,8 @@ var (
 	// XCALL Methods
 	MethodExecuteCall     = "executeCall"
 	MethodExecuteRollback = "executeRollback"
+
+	// Cluster Methods
+	MethodRegisterPacket    = "registerPacket"
+	MethodAcknowledgePacket = "acknowledgePacket"
 )

--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -12,6 +12,7 @@ import (
 	providerTypes "github.com/icon-project/centralized-relay/relayer/types"
 	"github.com/icon-project/goloop/module"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/sha3"
 )
 
 type Config struct {
@@ -275,4 +276,21 @@ func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
 // GetLastSavedBlockHeight returns the last saved block height
 func (p *Provider) GetLastSavedBlockHeight() uint64 {
 	return p.LastSavedHeightFunc()
+}
+
+func (p *Config) GetConncontract() string {
+	return p.Contracts[providerTypes.ConnectionContract]
+}
+
+func (p *Provider) SignMessage(message []byte) ([]byte, error) {
+	wallet, err := p.Wallet()
+	if err != nil {
+		p.log.Error("error getting wallets", zap.Error(err))
+		return nil, err
+	}
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write(message)
+	msgHash := hash.Sum(nil)
+	signedMsg, err := wallet.Sign(msgHash)
+	return signedMsg, err
 }

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -33,7 +33,25 @@ func (p *Provider) Route(ctx context.Context, message *providerTypes.Message, ca
 
 func (p *Provider) MakeIconMessage(message *providerTypes.Message) (*IconMessage, error) {
 	switch message.EventType {
+	case events.AcknowledgeMessage:
+		msg := &types.AcknowledgePacket{
+			Source:      message.Src,
+			Sn:          types.NewHexInt(message.Sn.Int64()),
+			SignedBytes: types.NewHexBytes(message.Data),
+		}
+		return p.NewIconMessage(p.GetAddressByEventType(events.AcknowledgeMessage), msg, MethodAcknowledgePacket), nil
 	case events.EmitMessage:
+		if p.cfg.ClusterMode {
+			msg := &types.RegisterPacket{
+				Data:        types.NewHexBytes(message.Data),
+				Sn:          types.NewHexInt(message.Sn.Int64()),
+				Height:      types.NewHexInt(int64(message.MessageHeight)),
+				Source:      message.Src,
+				Destination: message.Dst,
+				ConnAddress: message.ConnAddress,
+			}
+			return p.NewIconMessage(p.GetAddressByEventType(events.AcknowledgeMessage), msg, MethodRegisterPacket), nil
+		}
 		msg := &types.RecvMessage{
 			SrcNID: message.Src,
 			ConnSn: types.NewHexInt(message.Sn.Int64()),
@@ -201,4 +219,107 @@ func (p *Provider) LogFailedTx(method string, result *types.TransactionResult, e
 		zap.Int64p("step_limit", &p.cfg.StepLimit),
 		zap.Error(err),
 	)
+}
+
+func (p *Provider) RegisterClusterMessage(ctx context.Context, message *providerTypes.Message, callback providerTypes.TxResponseFunc) error {
+	p.log.Info("starting to register message",
+		zap.Any("sn", message.Sn),
+		zap.Any("req_id", message.ReqID),
+		zap.String("src", message.Src),
+		zap.String("event_type", message.EventType))
+	iconMessage, err := p.MakeIconMessage(message)
+	if err != nil {
+		return err
+	}
+	messageKey := message.MessageKey()
+	txhash, err := p.SendTransaction(ctx, iconMessage)
+	if err != nil {
+		return errors.Wrapf(err, "error occured while sending transaction")
+	}
+	return p.WaitForTxResult(ctx, txhash, messageKey, iconMessage.Method, callback)
+}
+
+func (p *Provider) AcknowledgeClusterMessage(ctx context.Context, message *providerTypes.Message, callback providerTypes.TxResponseFunc) error {
+	p.log.Info("starting to acknowledge message",
+		zap.Any("sn", message.Sn),
+		zap.Any("req_id", message.ReqID),
+		zap.String("src", message.Src),
+		zap.String("event_type", message.EventType))
+
+	iconMessage, err := p.MakeIconMessage(message)
+	if err != nil {
+		return err
+	}
+	messageKey := message.MessageKey()
+	txhash, err := p.SendTransaction(ctx, iconMessage)
+	if err != nil {
+		return errors.Wrapf(err, "error occured while sending transaction")
+	}
+	return p.WaitForTxResult(ctx, txhash, messageKey, iconMessage.Method, callback)
+}
+
+func (p *Provider) VerifyMessage(ctx context.Context, key *providerTypes.MessageKeyWithMessageHeight) ([]*providerTypes.Message, error) {
+	p.log.Info("Verifying message", zap.Any("messagekey", key))
+	if key == nil {
+		return nil, errors.New("GenerateMessage: message key cannot be nil")
+	}
+
+	block, err := p.client.GetBlockByHeight(&types.BlockHeightParam{
+		Height: types.NewHexInt(int64(key.Height)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GenerateMessage:GetBlockByHeight %v", err)
+	}
+	var messages []*providerTypes.Message
+	for _, res := range block.NormalTransactions {
+		txResult, err := p.client.GetTransactionResult(&types.TransactionHashParam{Hash: res.TxHash})
+		if err != nil {
+			return nil, fmt.Errorf("GenerateMessage:GetTransactionResult %v", err)
+		}
+
+		for _, el := range txResult.EventLogs {
+			var (
+				dst       string
+				eventType = p.GetEventName(el.Indexed[0])
+			)
+			height, err := txResult.BlockHeight.BigInt()
+			if err != nil {
+				return nil, fmt.Errorf("GenerateMessage: bigIntConversion %v", err)
+			}
+			switch el.Indexed[0] {
+			case EmitMessage:
+				if len(el.Indexed) != 3 || len(el.Data) != 1 {
+					continue
+				}
+				if len(el.Indexed) != 3 || len(el.Data) != 1 {
+					continue
+				}
+				dst = el.Indexed[1]
+				sn, err := types.HexInt(el.Indexed[2]).BigInt()
+				if err != nil {
+					p.log.Error("GenerateMessage: error decoding int value ")
+					continue
+				}
+				data := types.HexBytes(el.Data[0])
+				dataValue, err := data.Value()
+				if err != nil {
+					p.log.Error("GenerateMessage: error decoding data ", zap.Error(err))
+					continue
+				}
+				msg := &providerTypes.Message{
+					MessageHeight: height.Uint64(),
+					EventType:     eventType,
+					Dst:           dst,
+					Src:           p.NID(),
+					Data:          dataValue,
+					Sn:            sn,
+				}
+				messages = append(messages, msg)
+			}
+		}
+	}
+	if len(messages) == 0 {
+		return nil, errors.New("GenerateMessage: no messages found")
+	}
+	return messages, nil
 }

--- a/relayer/chains/icon/types/types.go
+++ b/relayer/chains/icon/types/types.go
@@ -385,3 +385,18 @@ type SetFee struct {
 type ExecuteRollback struct {
 	Sn HexInt `json:"_sn"`
 }
+
+type RegisterPacket struct {
+	Data        HexBytes `json:"data"`
+	Sn          HexInt   `json:"SN"`
+	Height      HexInt   `json:"height"`
+	Source      string   `json:"source"`
+	Destination string   `json:"destination"`
+	ConnAddress string   `json:"connAddr"`
+}
+
+type AcknowledgePacket struct {
+	Source      string   `json:"source"`
+	Sn          HexInt   `json:"SN"`
+	SignedBytes HexBytes `json:"signedBytes"`
+}

--- a/relayer/chains/mockchain/provider.go
+++ b/relayer/chains/mockchain/provider.go
@@ -206,3 +206,11 @@ func (p *MockProvider) SetFee(context.Context, string, *big.Int, *big.Int) error
 func (p *MockProvider) SetLastSavedHeightFunc(func() uint64) {
 
 }
+
+func (p *MockProviderConfig) GetConncontract() string {
+	return ""
+}
+
+func (ip *MockProvider) SignMessage(message []byte) ([]byte, error) {
+	return message, nil
+}

--- a/relayer/chains/steller/provider.go
+++ b/relayer/chains/steller/provider.go
@@ -182,3 +182,11 @@ func (p *Provider) ShouldSendMessage(ctx context.Context, messageKey *relayertyp
 func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
 	p.LastSavedHeightFunc = f
 }
+
+func (p *Config) GetConncontract() string {
+	return p.Contracts[relayertypes.ConnectionContract]
+}
+
+func (p *Provider) SignMessage(message []byte) ([]byte, error) {
+	return p.wallet.Sign(message)
+}

--- a/relayer/chains/sui/config.go
+++ b/relayer/chains/sui/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Config struct {
+	provider.CommonConfig
 	ChainName string `yaml:"-" json:"-"`
 	ChainID   string `yaml:"chain-id" json:"chain-id"`
 	RPCUrl    string `yaml:"rpc-url" json:"rpc-url"`
@@ -90,4 +91,8 @@ func (pc *Config) Validate() error {
 // Enabled returns true if the chain is enabled
 func (c *Config) Enabled() bool {
 	return !c.Disabled
+}
+
+func (pc *Config) GetConncontract() string {
+	return pc.ConnectionID
 }

--- a/relayer/chains/sui/provider.go
+++ b/relayer/chains/sui/provider.go
@@ -233,3 +233,7 @@ func (p *Provider) ShouldReceiveMessage(ctx context.Context, messagekey *relayer
 func (p *Provider) ShouldSendMessage(ctx context.Context, messageKey *relayertypes.Message) (bool, error) {
 	return true, nil
 }
+
+func (p *Provider) SignMessage(message []byte) ([]byte, error) {
+	return p.wallet.Sign(message), nil
+}

--- a/relayer/chains/wasm/client.go
+++ b/relayer/chains/wasm/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosmos/go-bip39"
 
 	txTypes "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 
 	bankTypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/icon-project/centralized-relay/relayer/chains/wasm/types"
@@ -48,6 +49,7 @@ type IClient interface {
 	Unsubscribe(ctx context.Context, _, query string) error
 	GetFee(ctx context.Context, addr string, queryData []byte) (uint64, error)
 	GetNetworkInfo(ctx context.Context) (*coretypes.ResultStatus, error)
+	SignMessage(uid string, message []byte) ([]byte, error)
 }
 
 type Client struct {
@@ -254,4 +256,10 @@ func (c *Client) Reconnect() error {
 	}
 	c.ctx.Client = client
 	return nil
+}
+
+// Signs the message with private key
+func (c *Client) SignMessage(uid string, message []byte) ([]byte, error) {
+	signedMsg, _, err := c.ctx.Keyring.Sign(uid, message, signing.SignMode_SIGN_MODE_DIRECT)
+	return signedMsg, err
 }

--- a/relayer/chains/wasm/config.go
+++ b/relayer/chains/wasm/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/icon-project/centralized-relay/relayer/chains/wasm/types"
 	"github.com/icon-project/centralized-relay/relayer/provider"
+	relayTypes "github.com/icon-project/centralized-relay/relayer/types"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -150,4 +151,8 @@ func (c *Config) newClientContext(ctx context.Context) (sdkClient.Context, error
 		GRPCClient:        grpcClient,
 		InterfaceRegistry: codec.InterfaceRegistry,
 	}, cometRPCClient.Start()
+}
+
+func (p *Config) GetConncontract() string {
+	return p.Contracts[relayTypes.ConnectionContract]
 }

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -852,3 +852,7 @@ func (p *Provider) SetLastSavedHeightFunc(f func() uint64) {
 func (p *Provider) GetLastSavedHeight() uint64 {
 	return p.LastSavedHeightFunc()
 }
+
+func (p *Provider) SignMessage(message []byte) ([]byte, error) {
+	return p.client.SignMessage(p.NID(), message)
+}

--- a/relayer/events/eventTypes.go
+++ b/relayer/events/eventTypes.go
@@ -11,4 +11,7 @@ const (
 	GetFee        = "getFee"
 	SetFee        = "setFee"
 	ClaimFee      = "claimFee"
+
+	// Cluster event types
+	AcknowledgeMessage = "acknowledgeMessage"
 )

--- a/relayer/provider/provider.go
+++ b/relayer/provider/provider.go
@@ -16,6 +16,7 @@ type Config interface {
 	GetWallet() string
 	Validate() error
 	Enabled() bool
+	GetConncontract() string
 }
 
 type ClusterConfig interface {
@@ -26,6 +27,15 @@ type ClusterConfig interface {
 type ChainQuery interface {
 	QueryLatestHeight(ctx context.Context) (uint64, error)
 	QueryTransactionReceipt(ctx context.Context, txHash string) (*types.Receipt, error)
+}
+
+type ClusterChainProvider interface {
+	RegisterClusterMessage(ctx context.Context, message *types.Message, callback types.TxResponseFunc) error
+	AcknowledgeClusterMessage(ctx context.Context, message *types.Message, callback types.TxResponseFunc) error
+}
+
+type ClusterChainVerifier interface {
+	VerifyMessage(ctx context.Context, messageKey *types.MessageKeyWithMessageHeight) ([]*types.Message, error)
 }
 
 type ChainProvider interface {
@@ -54,6 +64,8 @@ type ChainProvider interface {
 	GetFee(context.Context, string, bool) (uint64, error)
 	SetFee(context.Context, string, *big.Int, *big.Int) error
 	ClaimFee(context.Context) error
+
+	SignMessage([]byte) ([]byte, error)
 }
 
 // CommonConfig is the common configuration for all chain providers

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -3,8 +3,11 @@ package relayer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/icon-project/centralized-relay/relayer/events"
+	"github.com/icon-project/centralized-relay/relayer/provider"
 	"github.com/icon-project/centralized-relay/relayer/store"
 	"github.com/icon-project/centralized-relay/relayer/types"
 	"go.uber.org/zap"
@@ -128,6 +131,9 @@ func (r *Relayer) StartChainListeners(ctx context.Context, errCh chan error) {
 	var eg errgroup.Group
 
 	for _, chainRuntime := range r.chains {
+		if !chainRuntime.Provider.Config().Enabled() {
+			continue
+		}
 		eg.Go(func() error {
 			lastProcessedTxInfo, err := r.lastProcessedTxStore.Get(chainRuntime.Provider.NID())
 			if err != nil {
@@ -149,6 +155,9 @@ func (r *Relayer) StartBlockProcessors(ctx context.Context, errorChan chan error
 	var eg errgroup.Group
 
 	for _, chainRuntime := range r.chains {
+		if !chainRuntime.Provider.Config().Enabled() {
+			continue
+		}
 		eg.Go(func() error {
 			for {
 				select {
@@ -185,7 +194,11 @@ func (r *Relayer) StartRouter(ctx context.Context, flushInterval time.Duration) 
 			go r.flushMessages(ctx)
 		case <-routeTimer.C:
 			// processMessage starting working on all the runtime Messages
-			r.processMessages(ctx)
+			if r.clusterMode {
+				r.processClusterMessages(ctx)
+			} else {
+				r.processMessages(ctx)
+			}
 		case <-heightTimer.C:
 			go r.SaveChainsBlockHeight(ctx)
 		case <-cleanMessageTimer.C:
@@ -317,7 +330,23 @@ func (r *Relayer) GetAllChainsRuntime() []*ChainRuntime {
 func (r *Relayer) callback(ctx context.Context, src, dst *ChainRuntime, key *types.MessageKey) types.TxResponseFunc {
 	return func(key *types.MessageKey, response *types.TxResponse, err error) {
 		routeMessage, ok := src.MessageCache.Get(key)
+		originaldst := key.Dst
 		if !ok {
+			if !r.clusterMode {
+				r.log.Error("key not found in messageCache", zap.Any("key", &key))
+				return
+			}
+			// fix for emitMessage as src/dst would be different
+			// for the actual processing in cluster mode
+			if key.EventType == events.EmitMessage {
+				routeMessage = &types.RouteMessage{
+					Message: &types.Message{
+						MessageHeight: 0,
+					},
+				}
+			}
+		}
+		if routeMessage == nil {
 			r.log.Error("key not found in messageCache", zap.Any("key", &key))
 			return
 		}
@@ -325,20 +354,26 @@ func (r *Relayer) callback(ctx context.Context, src, dst *ChainRuntime, key *typ
 			dst.log.Info("message relayed successfully",
 				zap.String("src", src.Provider.NID()),
 				zap.String("dst", dst.Provider.NID()),
-				zap.String("event_type", routeMessage.EventType),
+				zap.String("event_type", key.EventType),
 				zap.Any("sn", key.Sn),
 				zap.String("tx_hash", response.TxHash),
 			)
+			if r.clusterMode && key.EventType == events.EmitMessage {
+				key.Dst = key.Src
+			}
 
 			// cannot clear incase of finality block
 			if dst.Provider.FinalityBlock(ctx) > 0 {
-				txObj := types.NewTransactionObject(types.NewMessagekeyWithMessageHeight(key, routeMessage.MessageHeight), response.TxHash, uint64(response.Height))
+				txObj := types.NewTransactionObject(
+					types.NewMessagekeyWithMessageHeight(key, routeMessage.MessageHeight),
+					response.TxHash, uint64(response.Height))
 				r.log.Info("storing txhash to check finality later", zap.Any("txObj", txObj))
 				if err := r.finalityStore.StoreTxObject(txObj); err != nil {
 					r.log.Error("error occured: while storing transaction object in db", zap.Error(err))
 					return
 				}
 			}
+			key.Dst = originaldst
 			// if success remove message from everywhere
 			if err := r.ClearMessages(ctx, []*types.MessageKey{key}, src); err != nil {
 				r.log.Error("error occured when clearing successful message", zap.Error(err))
@@ -408,6 +443,9 @@ func (r *Relayer) StartFinalityProcessor(ctx context.Context) {
 
 func (r *Relayer) CheckFinality(ctx context.Context) {
 	for nid, c := range r.chains {
+		if !c.Provider.Config().Enabled() {
+			continue
+		}
 		// check for the finality only if finalityblock is provided by the chain
 		finalityBlock := c.Provider.FinalityBlock(ctx)
 		latestHeight := c.LastBlockHeight
@@ -532,4 +570,119 @@ func (r *Relayer) cleanExpiredMessages(ctx context.Context) {
 			}
 		}
 	}
+}
+
+func getIconChain(chains map[string]*ChainRuntime) *ChainRuntime {
+	for _, v := range chains {
+		if v.Provider.Type() == "icon" && strings.Contains(v.Provider.NID(), "icon") {
+			return v
+		}
+	}
+	return nil
+}
+
+func (r *Relayer) processClusterMessages(ctx context.Context) {
+	for _, src := range r.chains {
+		for _, message := range src.MessageCache.Messages {
+			dst, err := r.FindChainRuntime(message.Dst)
+			if err != nil {
+				r.log.Error("dst chain nid not found", zap.String("nid", message.Dst))
+				r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
+				continue
+			}
+
+			if ok := dst.shouldSendMessage(ctx, message, src); !ok {
+				r.log.Debug("processing", zap.Any("message", message))
+				continue
+			}
+			message.ToggleProcessing()
+			switch message.EventType {
+			case events.EmitMessage:
+				message.Message.ConnAddress = dst.Provider.Config().GetConncontract()
+				iconChain := getIconChain(r.chains)
+				go r.RegisterClusterMessage(ctx, message, iconChain)
+			case events.AcknowledgeMessage:
+				srcChainProvider, err := r.FindChainRuntime(message.Src)
+				if err != nil {
+					r.log.Error("wrapped src chain nid not found", zap.String("nid", message.Src))
+					r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
+					continue
+				}
+				iconChain := getIconChain(r.chains)
+				go r.processAcknowledgementMsg(ctx, message, srcChainProvider, dst, iconChain)
+			default:
+				// if message reached delete the message
+				messageReceived, err := dst.Provider.MessageReceived(ctx, message.MessageKey())
+				if err != nil {
+					dst.log.Error("error occured when checking message received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()), zap.Error(err))
+					message.ToggleProcessing()
+					continue
+				}
+
+				// if message is received we can remove the message from db
+				if messageReceived {
+					dst.log.Info("message already received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()))
+					r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
+					continue
+				}
+				go r.RouteMessage(ctx, message, dst, src)
+			}
+		}
+	}
+}
+
+func (r *Relayer) RegisterClusterMessage(ctx context.Context, m *types.RouteMessage, iconChain *ChainRuntime) {
+	m.IncrementRetry()
+	if clusterProvider, ok := iconChain.Provider.(provider.ClusterChainProvider); ok {
+		if err := clusterProvider.RegisterClusterMessage(ctx, m.Message,
+			r.callback(ctx, iconChain, iconChain, m.MessageKey())); err != nil {
+			iconChain.log.Error("message register failed", zap.String("src", m.Src), zap.String("event_type", m.EventType), zap.Error(err))
+			r.HandleMessageFailed(m, iconChain, iconChain)
+		}
+		return
+	}
+	r.log.Warn("no provider found for registering cluster message")
+}
+
+func (r *Relayer) processAcknowledgementMsg(ctx context.Context, message *types.RouteMessage, src, dst, iconChain *ChainRuntime) {
+	var messages []*types.Message
+	var err error
+	if clusterProvider, ok := src.Provider.(provider.ClusterChainVerifier); ok {
+		messages, err = clusterProvider.VerifyMessage(ctx, &types.MessageKeyWithMessageHeight{
+			Height: message.WrappedSourceHeight.Uint64(),
+		})
+	} else {
+		messages, err = src.Provider.GenerateMessages(ctx, &types.MessageKeyWithMessageHeight{
+			Height: message.WrappedSourceHeight.Uint64(),
+		})
+	}
+	if err != nil {
+		r.log.Error("required message not found", zap.String("nid", message.Dst),
+			zap.Uint64("nid", message.MessageHeight))
+		message.IncrementRetry()
+		message.ToggleProcessing()
+		return
+	}
+	message.Data, err = dst.Provider.SignMessage(message.Data)
+	if err != nil {
+		r.log.Error("Error signing message", zap.Error(err))
+		return
+	}
+	for _, msg := range messages {
+		if msg.Sn.Cmp(message.Sn) == 0 {
+			r.AcknowledgeClusterMessage(ctx, message, src, iconChain)
+		}
+	}
+}
+
+func (r *Relayer) AcknowledgeClusterMessage(ctx context.Context, m *types.RouteMessage, src, iconChain *ChainRuntime) {
+	m.IncrementRetry()
+	if clusterProvider, ok := iconChain.Provider.(provider.ClusterChainProvider); ok {
+		if err := clusterProvider.AcknowledgeClusterMessage(ctx, m.Message, r.callback(ctx, iconChain, iconChain, m.MessageKey())); err != nil {
+			iconChain.log.Error("message acknowledgement failed", zap.String("src", m.Src), zap.String("event_type", m.EventType), zap.Error(err))
+			r.HandleMessageFailed(m, iconChain, iconChain)
+		}
+		return
+	}
+	r.log.Warn("no provider found for acknowledging cluster message")
 }

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -10,13 +10,14 @@ import (
 )
 
 var (
-	MaxTxRetry         uint8 = 5
-	StaleMarkCount           = MaxTxRetry * 3
-	RouteDuration            = 3 * time.Second
-	XcallContract            = "xcall"
-	ConnectionContract       = "connection"
-	SupportedContracts       = []string{XcallContract, ConnectionContract}
-	RetryInterval            = 3*time.Second + RouteDuration
+	MaxTxRetry          uint8 = 5
+	StaleMarkCount            = MaxTxRetry * 3
+	RouteDuration             = 3 * time.Second
+	XcallContract             = "xcall"
+	ConnectionContract        = "connection"
+	AggregationContract       = "aggregation"
+	SupportedContracts        = []string{XcallContract, ConnectionContract}
+	RetryInterval             = 3*time.Second + RouteDuration
 )
 
 type BlockInfo struct {
@@ -25,14 +26,16 @@ type BlockInfo struct {
 }
 
 type Message struct {
-	Dst             string   `json:"dst"`
-	Src             string   `json:"src"`
-	Sn              *big.Int `json:"sn"`
-	Data            []byte   `json:"data"`
-	MessageHeight   uint64   `json:"messageHeight"`
-	EventType       string   `json:"eventType"`
-	ReqID           *big.Int `json:"reqID,omitempty"`
-	DappModuleCapID string   `json:"dappModuleCapID,omitempty"`
+	Dst                 string   `json:"dst"`
+	Src                 string   `json:"src"`
+	Sn                  *big.Int `json:"sn"`
+	Data                []byte   `json:"data"`
+	MessageHeight       uint64   `json:"messageHeight"`
+	EventType           string   `json:"eventType"`
+	ReqID               *big.Int `json:"reqID,omitempty"`
+	DappModuleCapID     string   `json:"dappModuleCapID,omitempty"`
+	WrappedSourceHeight *big.Int `json:"height"`
+	ConnAddress         string   `json:"conn-addr"`
 
 	TxInfo []byte `json:"-"`
 }


### PR DESCRIPTION
Added new aggragation contract listener with emitting events packet acknowledge.
For cluster mode, regular emitEvents are handled for registration in the aggregation contracts and then for packetAcknowledgement event, it queries the chain for the message in specific height and then acknowledges the message with signed bytes.