### PR TITLE
fix: solana concurrency issue

### DIFF
--- a/relayer/chains/solana/client.go
+++ b/relayer/chains/solana/client.go
@@ -191,7 +191,10 @@ func (cl Client) GetLatestSlot(ctx context.Context, ctype solrpc.CommitmentType)
 }
 
 func (cl Client) GetBlock(ctx context.Context, slot uint64) (*solrpc.GetBlockResult, error) {
-	return cl.rpc.GetBlock(ctx, slot)
+	txnVersion := uint64(0)
+	return cl.rpc.GetBlockWithOpts(ctx, slot, &solrpc.GetBlockOpts{
+		MaxSupportedTransactionVersion: &txnVersion,
+	})
 }
 
 func (cl Client) GetLatestBlockHash(ctx context.Context) (*solana.Hash, error) {

--- a/relayer/chains/solana/listener.go
+++ b/relayer/chains/solana/listener.go
@@ -171,15 +171,18 @@ func (p *Provider) parseMessagesFromEvent(solEvent types.SolEvent) ([]*relayerty
 							return nil, fmt.Errorf("failed to decode call message event: %w", err)
 						}
 						fromNID := strings.Split(cmEvent.FromNetworkAddress, "/")[0]
+						connProgram := solana.PublicKeyFromBytes(cmEvent.ConnProgram[:]).String()
 						messages = append(messages, &relayertypes.Message{
-							EventType:     relayerevents.CallMessage,
-							Sn:            &cmEvent.Sn,
-							ReqID:         &cmEvent.ReqId,
-							Src:           fromNID,
-							Dst:           p.NID(),
-							Data:          cmEvent.Data,
-							MessageHeight: solEvent.Slot,
-							TxInfo:        txInfoBytes,
+							EventType:      relayerevents.CallMessage,
+							Sn:             &cmEvent.ConnSn,
+							XcallSn:        &cmEvent.Sn,
+							ReqID:          &cmEvent.ReqId,
+							Src:            fromNID,
+							Dst:            p.NID(),
+							Data:           cmEvent.Data,
+							MessageHeight:  solEvent.Slot,
+							TxInfo:         txInfoBytes,
+							DstConnAddress: connProgram,
 						})
 
 					case types.EventRollbackMessage:

--- a/relayer/chains/solana/provider_test.go
+++ b/relayer/chains/solana/provider_test.go
@@ -63,7 +63,7 @@ func TestIDLAddress(t *testing.T) {
 }
 
 func TestEventLogParse(t *testing.T) {
-	eventData := "HDQnaQjSWwkIAAAAMHgzLmljb24BAAAAAAAAAA=="
+	eventData := "fWThb0jJunszAAAAMHgyLmljb24vY3g4N2Y3ZjhjZWFhMDU0ZDQ2YmE3MzQzYTJlY2QyMTIwOGUxMjkxM2M2LAAAAEFoczljQzZQTUdoYXNCNXpVYm9VVk5CSnhBU3RtWDFhZUVORGlXTHoyQVhI6C0AAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAACGAAAA+ISOeENyb3NzVHJhbnNmZXKzMHgyLmljb24vaHhlYTM2MzVmNzQ5NTY1M2Q4NTk2YTdmMjNhNzg1MTRiNmFkMTQ3MGU4uDhzb2xhbmEtdGVzdC85Rzk0SDNmYk5lVVVyZ0RZa3NicGk4SzNZRWpUdTh4S1JodHFXSDdISnpKaYUCVAvkAID237SBcyKtv1NpOLhakI9pELfsH15KMoYBJx2exUH/vjYBAAAAAAAAAAAAAAAAAAA="
 
 	// Decode the Base64 encoded string
 	eventBytes, err := base64.StdEncoding.DecodeString(eventData)
@@ -81,10 +81,7 @@ func TestEventLogParse(t *testing.T) {
 	// Remaining bytes are the serialized event
 	remainingBytes := eventBytes[8:]
 
-	ev := struct {
-		To string
-		Sn uint64
-	}{}
+	ev := types.CallMessageEvent{}
 
 	// Deserialize the remaining bytes into the TestEvent struct
 	err = borsh.Deserialize(&ev, remainingBytes)

--- a/relayer/chains/solana/types/types.go
+++ b/relayer/chains/solana/types/types.go
@@ -56,6 +56,8 @@ type CallMessageEvent struct {
 	Sn                 big.Int
 	ReqId              big.Int
 	Data               []byte
+	ConnProgram        solana.PublicKey
+	ConnSn             big.Int
 }
 
 type RollbackMessageEvent struct {

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -28,11 +28,13 @@ type Message struct {
 	Dst             string   `json:"dst"`
 	Src             string   `json:"src"`
 	Sn              *big.Int `json:"sn"`
+	XcallSn         *big.Int `json:"xcallSN,omitempty"`
 	Data            []byte   `json:"data"`
 	MessageHeight   uint64   `json:"messageHeight"`
 	EventType       string   `json:"eventType"`
 	ReqID           *big.Int `json:"reqID,omitempty"`
 	DappModuleCapID string   `json:"dappModuleCapID,omitempty"`
+	DstConnAddress  string   `json:"dstConnAddress,omitempty"`
 
 	TxInfo []byte `json:"-"`
 }


### PR DESCRIPTION
When sending multiple transactions concurrently to the SOLANA chain, the contract had a bug of dirty reads of the `last_saved_req_id`(all proxy requests got the same last_saved_req_id) before the message was received which failed all the concurrent transactions except the first one. This PR includes the changes to be made on the relayer side to incorporate the changes made on the contract side to fix the bug. The solution was to create a proxy request account using src_nid, src_conn_sn, and the dst_conn_addr of the relayer.