### PR TITLE
fix: wrong xcallsn

### DIFF
--- a/relayer/chains/solana/listener.go
+++ b/relayer/chains/solana/listener.go
@@ -194,7 +194,7 @@ func (p *Provider) parseMessagesFromEvent(solEvent types.SolEvent) ([]*relayerty
 						}
 						messages = append(messages, &relayertypes.Message{
 							EventType:     relayerevents.RollbackMessage,
-							Sn:            &rmEvent.Sn,
+							XcallSn:       &rmEvent.Sn,
 							Src:           p.NID(),
 							Dst:           p.NID(),
 							MessageHeight: solEvent.Slot,

--- a/relayer/relay.go
+++ b/relayer/relay.go
@@ -254,14 +254,14 @@ func (r *Relayer) processMessages(ctx context.Context) {
 
 			messageReceived, err := dst.Provider.MessageReceived(ctx, message.MessageKey())
 			if err != nil {
-				dst.log.Error("error occured when checking message received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()), zap.Error(err))
+				dst.log.Error("error occured when checking message received", zap.String("src", message.Src), zap.Any("sn", message.Sn), zap.Error(err))
 				message.ToggleProcessing()
 				continue
 			}
 
 			// if message is received we can remove the message from db
 			if messageReceived {
-				dst.log.Info("message already received", zap.String("src", message.Src), zap.Uint64("sn", message.Sn.Uint64()))
+				dst.log.Info("message already received", zap.String("src", message.Src), zap.Any("sn", message.Sn))
 				r.ClearMessages(ctx, []*types.MessageKey{message.MessageKey()}, src)
 				continue
 			}


### PR DESCRIPTION
There was nil pointer dereference error while executing Rollback in solana due to XcallSn being not set in the Message. This is fixed in this PR.