### PR TITLE
refactor: round floating decimals to three places in calculations

### DIFF
--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -227,7 +227,8 @@ func (c *Coin) String() string {
 func (c *Coin) Calculate() string {
 	factor := math.Pow10(c.Decimals)
 	val := new(big.Float).Quo(new(big.Float).SetUint64(c.Amount), big.NewFloat(factor))
-	return val.String()
+	val = val.SetMode(big.ToNearestEven)
+	return fmt.Sprintf("%.3f", val)
 }
 
 type TransactionObject struct {


### PR DESCRIPTION
Adjust the calculation method to round floating-point values to three decimal places for improved precision in the output.