### PR TITLE
fix: balance queries to handle failures gracefully

### DIFF
--- a/relayer/socket/server.go
+++ b/relayer/socket/server.go
@@ -308,7 +308,7 @@ func (s *Server) parseEvent(msg *Request) *Response {
 			}
 			balance, err := chain.Provider.QueryBalance(ctx, req.Address)
 			if err != nil {
-				return response.SetError(err)
+				balance = types.NewCoin("", 0, 0)
 			}
 			res = append(res, &ResGetBalance{Chain: req.Chain, Address: req.Address, Balance: balance, Value: balance.Calculate()})
 		}

--- a/relayer/types/types.go
+++ b/relayer/types/types.go
@@ -227,7 +227,6 @@ func (c *Coin) String() string {
 func (c *Coin) Calculate() string {
 	factor := math.Pow10(c.Decimals)
 	val := new(big.Float).Quo(new(big.Float).SetUint64(c.Amount), big.NewFloat(factor))
-	val = val.SetMode(big.ToNearestEven)
 	return fmt.Sprintf("%.3f", val)
 }
 


### PR DESCRIPTION
Balance queries now return a default value when a query fails, preventing the entire operation from failing. Additionally, removed unnecessary rounding mode in the coin calculation.