### PR TITLE
fix: set SDK context before account creation

### DIFF
--- a/relayer/chains/wasm/keys.go
+++ b/relayer/chains/wasm/keys.go
@@ -35,12 +35,12 @@ func (p *Provider) RestoreKeystore(ctx context.Context) error {
 }
 
 func (p *Provider) NewKeystore(passphrase string) (string, error) {
+	done := p.SetSDKContext()
+	defer done()
 	armor, addr, err := p.client.CreateAccount(p.NID(), passphrase)
 	if err != nil {
 		return "", err
 	}
-	done := p.SetSDKContext()
-	defer done()
 	encryptedArmor, err := p.kms.Encrypt(context.Background(), []byte(armor))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Ensure the SDK context is set prior to creating an account in the keystore. This change improves the reliability of the account creation process.