### PR TITLE
fix: CI configuration issues in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,13 @@ release-dry-run:
 		--clean --auto-snapshot
 
 .PHONY: release
+release:
 	docker run \
 		--rm \
 		--env GITHUB_TOKEN \
 		--env LIBWASM_VERSION=$(LIBWASM_VERSION) \
-		--env COSIGN_PASSWORD=(env COSIGN_PASSWORD) \
-		--env COSIGN_PRIVATE_KEY(env COSIGN_PRIVATE_KEY) \
+		--env COSIGN_PASSWORD=(COSIGN_PASSWORD) \
+		--env COSIGN_PRIVATE_KEY(COSIGN_PRIVATE_KEY) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ release:
 		--rm \
 		--env GITHUB_TOKEN \
 		--env LIBWASM_VERSION=$(LIBWASM_VERSION) \
-		--env COSIGN_PASSWORD=(COSIGN_PASSWORD) \
-		--env COSIGN_PRIVATE_KEY(COSIGN_PRIVATE_KEY) \
+		--env COSIGN_PASSWORD \
+		--env COSIGN_PRIVATE_KEY \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \


### PR DESCRIPTION
Correctly specify the directory for the CI process and remove the unnecessary section name for the release target.