### PR TITLE
fix: relayer version docker build argument formatting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            - RELAYER_VERSION=${{ github.ref_name }}
+            RELAYER_VERSION=${{ github.ref_name }}
           tags: |
             iconcommunity/centralized-relay:latest
             iconcommunity/centralized-relay:${{ github.ref_name }}


### PR DESCRIPTION
Adjust the formatting of the Docker build argument for the relayer version in the release workflow.