### PR TITLE
fix: Strip 'v' from version in Docker build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            RELAYER_VERSION=${{ github.ref_name }}
+            RELAYER_VERSION=${GITHUB_REF#refs/tags/v}
           tags: |
             iconcommunity/centralized-relay:latest
             iconcommunity/centralized-relay:${{ github.ref_name }}


### PR DESCRIPTION
Remove the 'v' prefix from the version when setting the `RELAYER_VERSION` in the Docker build process.