### PR TITLE
fix: enable to use legacy fee for evm

### DIFF
--- a/relayer/chains/evm/provider.go
+++ b/relayer/chains/evm/provider.go
@@ -45,6 +45,7 @@ var (
 type Config struct {
 	provider.CommonConfig `json:",inline" yaml:",inline"`
 	WebsocketUrl          string `json:"websocket-url" yaml:"websocket-url"`
+	UseLegacyFee          bool   `json:"use-legacy-fee" yaml:"use-legacy-fee"`
 	GasMin                uint64 `json:"gas-min" yaml:"gas-min"`
 	GasLimit              uint64 `json:"gas-limit" yaml:"gas-limit"`
 	GasAdjustment         uint64 `json:"gas-adjustment" yaml:"gas-adjustment"`
@@ -266,12 +267,22 @@ func (p *Provider) GetTransationOpts(ctx context.Context) (*bind.TransactOpts, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to get gas price: %w", err)
 	}
-	gasTip, err := p.client.SuggestGasTip(ctx)
-	if err != nil {
-		p.log.Warn("failed to get gas tip", zap.Error(err))
+
+	if p.cfg.UseLegacyFee {
+		txOpts.GasPrice = gasPrice
+		if p.cfg.GasAdjustment > 0 {
+			adjustedGasPrice := gasPrice.Uint64() + (gasPrice.Uint64() * p.cfg.GasAdjustment / 100)
+			txOpts.GasPrice = big.NewInt(int64(adjustedGasPrice))
+		}
+	} else {
+		gasTip, err := p.client.SuggestGasTip(ctx)
+		if err != nil {
+			p.log.Warn("failed to get gas tip", zap.Error(err))
+		}
+		txOpts.GasFeeCap = gasPrice.Mul(gasPrice, big.NewInt(2))
+		txOpts.GasTipCap = gasTip
 	}
-	txOpts.GasFeeCap = gasPrice.Mul(gasPrice, big.NewInt(2))
-	txOpts.GasTipCap = gasTip
+
 	return txOpts, nil
 }
 

--- a/relayer/chains/evm/route.go
+++ b/relayer/chains/evm/route.go
@@ -74,6 +74,7 @@ func (p *Provider) SendTransaction(ctx context.Context, opts *bind.TransactOpts,
 	opts.GasLimit = gasLimit + (gasLimit * p.cfg.GasAdjustment / 100)
 
 	p.log.Info("transaction info",
+		zap.Any("gas_price", opts.GasPrice),
 		zap.Uint64("gas_cap", opts.GasFeeCap.Uint64()),
 		zap.Uint64("gas_tip", opts.GasTipCap.Uint64()),
 		zap.Uint64("estimated_limit", gasLimit),


### PR DESCRIPTION
## Description:
Currently the transactions in BNB smart chain are stucked in the mempool for long time. The issue might be due to the EIP-1559 gas pricing strategy that we used by default for all evm chains. Since base fee is zero, using legacy gas pricing might help.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines]
- [ ] I have run the E2E Test 
(https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
