### PR TITLE
fix: use default step if estimation fails

### DIFF
--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -19,6 +19,7 @@ import (
 
 type Config struct {
 	provider.CommonConfig `json:",inline" yaml:",inline"`
+	StepDefault           int64 `json:"step-default" yaml:"step-default"`
 	StepMin               int64 `json:"step-min" yaml:"step-min"`
 	StepLimit             int64 `json:"step-limit" yaml:"step-limit"`
 	StepAdjustment        int64 `json:"step-adjustment" yaml:"step-adjustment"`

--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -19,6 +19,7 @@ import (
 
 type Config struct {
 	provider.CommonConfig `json:",inline" yaml:",inline"`
+	SkipSimulation        bool  `json:"skip-simulation" yaml:"skip-simulation"`
 	StepDefault           int64 `json:"step-default" yaml:"step-default"`
 	StepMin               int64 `json:"step-min" yaml:"step-min"`
 	StepLimit             int64 `json:"step-limit" yaml:"step-limit"`

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -138,12 +138,12 @@ func (p *Provider) SendTransaction(ctx context.Context, msg *IconMessage) ([]byt
 
 	step, err := p.client.EstimateStep(txParam)
 	if err != nil {
-		p.log.Warn("failed estimating step, using default step", zap.Error(err))
-		defaultStep := types.NewHexInt(2_000_000)
 		if p.cfg.StepDefault > 0 {
-			defaultStep = types.NewHexInt(p.cfg.StepDefault)
+			defaultStep := types.NewHexInt(p.cfg.StepDefault)
+			step = &defaultStep
+		} else {
+			return nil, fmt.Errorf("failed estimating step: %w", err)
 		}
-		step = &defaultStep
 	}
 
 	steps, err := step.Int64()

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -136,17 +136,19 @@ func (p *Provider) SendTransaction(ctx context.Context, msg *IconMessage) ([]byt
 		},
 	}
 
-	step, err := p.client.EstimateStep(txParam)
-	if err != nil {
-		if p.cfg.StepDefault > 0 {
-			defaultStep := types.NewHexInt(p.cfg.StepDefault)
-			step = &defaultStep
-		} else {
+	stepsHexInt := types.NewHexInt(2_000_000)
+	if p.cfg.StepDefault > 0 {
+		stepsHexInt = types.NewHexInt(p.cfg.StepDefault)
+	}
+	if !p.cfg.SkipSimulation {
+		simSteps, err := p.client.EstimateStep(txParam)
+		if err != nil {
 			return nil, fmt.Errorf("failed estimating step: %w", err)
 		}
+		stepsHexInt = *simSteps
 	}
 
-	steps, err := step.Int64()
+	steps, err := stepsHexInt.Int64()
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/chains/icon/route.go
+++ b/relayer/chains/icon/route.go
@@ -138,7 +138,12 @@ func (p *Provider) SendTransaction(ctx context.Context, msg *IconMessage) ([]byt
 
 	step, err := p.client.EstimateStep(txParam)
 	if err != nil {
-		return nil, fmt.Errorf("failed estimating step: %w", err)
+		p.log.Warn("failed estimating step, using default step", zap.Error(err))
+		defaultStep := types.NewHexInt(2_000_000)
+		if p.cfg.StepDefault > 0 {
+			defaultStep = types.NewHexInt(p.cfg.StepDefault)
+		}
+		step = &defaultStep
 	}
 
 	steps, err := step.Int64()


### PR DESCRIPTION
## Description:
Currently in icon if txn fails while estimating steps, no any debugging information is returned in the response. So, it is better to continue with default steps and execute txn so that the cause of failure can be known.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines]
- [ ] I have run the E2E Test 
(https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
