### PR TITLE
fix: check message receipt before execution for cluster

### DIFF
--- a/relayer/chains/evm/query.go
+++ b/relayer/chains/evm/query.go
@@ -28,7 +28,7 @@ func (p *Provider) ShouldSendMessage(ctx context.Context, messageKey *types.Mess
 
 func (p *Provider) MessageReceived(ctx context.Context, msg *types.Message) (bool, error) {
 	switch msg.EventType {
-	case events.EmitMessage:
+	case events.EmitMessage, events.PacketRegistered, events.PacketAcknowledged:
 		ctx, cancel := context.WithTimeout(ctx, defaultReadTimeout)
 		defer cancel()
 		return p.client.MessageReceived(&bind.CallOpts{Context: ctx}, msg.Src, msg.Sn)

--- a/relayer/chains/icon/provider.go
+++ b/relayer/chains/icon/provider.go
@@ -193,7 +193,7 @@ func (p *Provider) FinalityBlock(ctx context.Context) uint64 {
 // MessageReceived checks if the message is received
 func (p *Provider) MessageReceived(ctx context.Context, msg *providerTypes.Message) (bool, error) {
 	switch msg.EventType {
-	case events.EmitMessage:
+	case events.EmitMessage, events.PacketRegistered, events.PacketAcknowledged:
 		callParam := p.prepareCallParams(MethodGetReceipts, p.cfg.Contracts[providerTypes.ConnectionContract], map[string]interface{}{
 			"srcNetwork": msg.Src,
 			"_connSn":    types.NewHexInt(msg.Sn.Int64()),

--- a/relayer/chains/solana/tx.go
+++ b/relayer/chains/solana/tx.go
@@ -1142,7 +1142,7 @@ func (p *Provider) MessageReceived(ctx context.Context, msg *relayertypes.Messag
 		}
 
 		return false, nil
-	case relayerevents.EmitMessage:
+	case relayerevents.EmitMessage, relayerevents.PacketRegistered, relayerevents.PacketAcknowledged:
 		receiptAc, err := p.pdaRegistry.ConnReceipt.GetAddress([]byte(msg.Src), msg.Sn.FillBytes(make([]byte, 16)))
 		if err != nil {
 			return false, err

--- a/relayer/chains/steller/tx.go
+++ b/relayer/chains/steller/tx.go
@@ -379,7 +379,7 @@ func (p *Provider) QueryTransactionReceipt(ctx context.Context, txHash string) (
 
 func (p *Provider) MessageReceived(ctx context.Context, msg *relayertypes.Message) (bool, error) {
 	switch msg.EventType {
-	case evtypes.EmitMessage:
+	case evtypes.EmitMessage, evtypes.PacketRegistered, evtypes.PacketAcknowledged:
 		connAddr, err := p.scContractAddr(p.cfg.Contracts[relayertypes.ConnectionContract])
 		if err != nil {
 			return false, err

--- a/relayer/chains/sui/tx.go
+++ b/relayer/chains/sui/tx.go
@@ -388,7 +388,7 @@ func (p *Provider) QueryTransactionReceipt(ctx context.Context, txDigest string)
 
 func (p *Provider) MessageReceived(ctx context.Context, msg *relayertypes.Message) (bool, error) {
 	switch msg.EventType {
-	case events.EmitMessage:
+	case events.EmitMessage, events.PacketRegistered, events.PacketAcknowledged:
 		snU128, err := bcs.NewUint128FromBigInt(msg.Sn)
 		if err != nil {
 			return false, err

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -402,7 +402,7 @@ func (p *Provider) subscribeTxResult(ctx context.Context, tx *sdkTypes.TxRespons
 
 func (p *Provider) MessageReceived(ctx context.Context, msg *relayTypes.Message) (bool, error) {
 	switch msg.EventType {
-	case events.EmitMessage:
+	case events.EmitMessage, events.PacketRegistered, events.PacketAcknowledged:
 		queryMsg := &types.QueryReceiptMsg{
 			GetReceipt: &types.GetReceiptMsg{
 				SrcNetwork: msg.Src,


### PR DESCRIPTION
## Description:
Currently in cluster relayer, messages are not checked before execution resulting to duplicate execution and failures.

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines]
- [ ] I have run the E2E Test 
(https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
